### PR TITLE
Centralize runplugin Kubernetes Deployment object in ResourceManager

### DIFF
--- a/cmd/runplugin/main.go
+++ b/cmd/runplugin/main.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	rabbithole "github.com/michaelklishin/rabbit-hole"
+	"github.com/sagecontinuum/ses/pkg/nodescheduler"
 	"github.com/sagecontinuum/ses/pkg/runplugin"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -86,9 +87,17 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// NOTE(sean) starting to centralize Kubernetes object functionality in ResourceManager
+	resourceManager, err := nodescheduler.NewK3SResourceManager("", false, kubeconfig, false)
+	if err != nil {
+		log.Fatal(err)
+	}
+	resourceManager.Namespace = "default"
+
 	sch := &runplugin.Scheduler{
 		KubernetesClientset: clientset,
 		RabbitMQClient:      rmqclient,
+		ResourceManager:     resourceManager,
 	}
 
 	args := flag.Args()

--- a/pkg/pluginctl/pluginctl.go
+++ b/pkg/pluginctl/pluginctl.go
@@ -93,7 +93,7 @@ func (p *PluginCtl) Deploy(dep *Deployment) (string, error) {
 			DevelopMode: dep.DevelopMode,
 		},
 	}
-	job, err := p.ResourceManager.CreateJob(&plugin)
+	job, err := p.ResourceManager.NewPluginJob(&plugin)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This PR moves making runplugin's Deployment object in ResourceManager and updates the runplugin package to use this instead of maintaining its own copy.

This should eliminate duplicate work whenever we have to update the plugin Pod template spec.