### PR TITLE
Cloud scheduler pushes goals to clients in the SSE stream

### DIFF
--- a/pkg/cloudscheduler/builder.go
+++ b/pkg/cloudscheduler/builder.go
@@ -3,18 +3,34 @@ package cloudscheduler
 import (
 	"github.com/waggle-sensor/edge-scheduler/pkg/datatype"
 	"github.com/waggle-sensor/edge-scheduler/pkg/interfacing"
+	"github.com/waggle-sensor/edge-scheduler/pkg/logger"
 )
+
+type CloudSchedulerConfig struct {
+	Name               string
+	Version            string
+	NoRabbitMQ         bool
+	RabbitmqURI        string
+	RabbitmqUsername   string
+	RabbitmqPassword   string
+	ECRURL             string
+	Port               int
+	DataDir            string
+	NoPushNotification bool
+}
 
 type RealCloudScheduler struct {
 	cloudScheduler *CloudScheduler
+	config         *CloudSchedulerConfig
 }
 
-func NewRealCloudSchedulerBuilder(name string, version string) *RealCloudScheduler {
+func NewRealCloudSchedulerBuilder(config *CloudSchedulerConfig) *RealCloudScheduler {
 	return &RealCloudScheduler{
 		cloudScheduler: &CloudScheduler{
-			Name:                name,
-			Version:             version,
-			Validator:           NewJobValidator(),
+			Name:                config.Name,
+			Version:             config.Version,
+			Config:              config,
+			Validator:           NewJobValidator(config.DataDir),
 			chanFromGoalManager: make(chan datatype.Event, maxChannelBuffer),
 		},
 	}
@@ -26,15 +42,32 @@ func (rcs *RealCloudScheduler) AddGoalManager() *RealCloudScheduler {
 		Notifier:     interfacing.NewNotifier(),
 		jobs:         make(map[string]*datatype.Job),
 	}
+	if !rcs.cloudScheduler.Config.NoRabbitMQ {
+		logger.Info.Printf(
+			"Using RabbitMQ at %s with user %s",
+			rcs.cloudScheduler.Config.RabbitmqURI,
+			rcs.cloudScheduler.Config.RabbitmqUsername,
+		)
+		rcs.cloudScheduler.GoalManager.SetRMQHandler(
+			interfacing.NewRabbitMQHandler(
+				rcs.cloudScheduler.Config.RabbitmqURI,
+				rcs.cloudScheduler.Config.RabbitmqUsername,
+				rcs.cloudScheduler.Config.RabbitmqPassword,
+				"",
+			),
+		)
+	}
 	rcs.cloudScheduler.GoalManager.Notifier.Subscribe(rcs.cloudScheduler.chanFromGoalManager)
 	return rcs
 }
 
-func (rcs *RealCloudScheduler) AddAPIServer(port int) *RealCloudScheduler {
+func (rcs *RealCloudScheduler) AddAPIServer() *RealCloudScheduler {
 	rcs.cloudScheduler.APIServer = &APIServer{
-		cloudScheduler: rcs.cloudScheduler,
-		version:        rcs.cloudScheduler.Version,
-		port:           port,
+		cloudScheduler:         rcs.cloudScheduler,
+		version:                rcs.cloudScheduler.Version,
+		port:                   rcs.cloudScheduler.Config.Port,
+		enablePushNotification: rcs.cloudScheduler.Config.NoPushNotification,
+		subscribers:            make(map[string]map[chan *datatype.Event]bool),
 	}
 	return rcs
 }

--- a/pkg/cloudscheduler/cloudgoalmanager.go
+++ b/pkg/cloudscheduler/cloudgoalmanager.go
@@ -54,7 +54,7 @@ func (cgm *CloudGoalManager) UpdateJob(job *datatype.Job, submit bool) {
 		job.UpdateStatus(datatype.JobSubmitted)
 		newScienceGoal := job.ScienceGoal
 		cgm.UpdateScienceGoal(newScienceGoal)
-		event := datatype.NewEventBuilder(datatype.EventGoalStatusNew).AddGoal(newScienceGoal).Build()
+		event := datatype.NewEventBuilder(datatype.EventGoalStatusSubmitted).AddGoal(newScienceGoal).Build()
 		cgm.Notifier.Notify(event)
 	}
 }
@@ -126,7 +126,7 @@ func (cgm *CloudGoalManager) GetScienceGoal(goalID string) (*datatype.ScienceGoa
 	return nil, fmt.Errorf("Failed to find goal %q", goalID)
 }
 
-// GetScienceGoalsForNode returns a list of goals associated to given node
+// GetScienceGoalsForNode returns a list of goals associated to given node.
 func (cgm *CloudGoalManager) GetScienceGoalsForNode(nodeName string) (goals []*datatype.ScienceGoal) {
 	for _, scienceGoal := range cgm.scienceGoals {
 		for _, subGoal := range scienceGoal.SubGoals {

--- a/pkg/cloudscheduler/validator.go
+++ b/pkg/cloudscheduler/validator.go
@@ -11,14 +11,16 @@ import (
 )
 
 type JobValidator struct {
-	Plugins map[string]*datatype.PluginManifest
-	Nodes   map[string]*datatype.NodeManifest
+	dataPath string
+	Plugins  map[string]*datatype.PluginManifest
+	Nodes    map[string]*datatype.NodeManifest
 }
 
-func NewJobValidator() *JobValidator {
+func NewJobValidator(dataPath string) *JobValidator {
 	return &JobValidator{
-		Plugins: make(map[string]*datatype.PluginManifest),
-		Nodes:   make(map[string]*datatype.NodeManifest),
+		dataPath: dataPath,
+		Plugins:  make(map[string]*datatype.PluginManifest),
+		Nodes:    make(map[string]*datatype.NodeManifest),
 	}
 }
 
@@ -38,13 +40,13 @@ func (jv *JobValidator) GetPluginManifest(plugin *datatype.Plugin) *datatype.Plu
 	}
 }
 
-func (jv *JobValidator) LoadDatabase(basePath string) error {
-	nodeFiles, err := ioutil.ReadDir(path.Join(basePath, "nodes"))
+func (jv *JobValidator) LoadDatabase() error {
+	nodeFiles, err := ioutil.ReadDir(path.Join(jv.dataPath, "nodes"))
 	if err != nil {
 		return err
 	}
 	for _, nodeFile := range nodeFiles {
-		nodeFilePath := path.Join(basePath, "nodes", nodeFile.Name())
+		nodeFilePath := path.Join(jv.dataPath, "nodes", nodeFile.Name())
 		raw, err := os.ReadFile(nodeFilePath)
 		if err != nil {
 			logger.Debug.Printf("Failed to read %s:%s", nodeFilePath, err.Error())
@@ -58,12 +60,12 @@ func (jv *JobValidator) LoadDatabase(basePath string) error {
 		}
 		jv.Nodes[n.Name] = &n
 	}
-	pluginFiles, err := ioutil.ReadDir(path.Join(basePath, "plugins"))
+	pluginFiles, err := ioutil.ReadDir(path.Join(jv.dataPath, "plugins"))
 	if err != nil {
 		return err
 	}
 	for _, pluginFile := range pluginFiles {
-		pluginFilePath := path.Join(basePath, "plugins", pluginFile.Name())
+		pluginFilePath := path.Join(jv.dataPath, "plugins", pluginFile.Name())
 		raw, err := os.ReadFile(pluginFilePath)
 		if err != nil {
 			logger.Debug.Printf("Failed to read %s:%s", pluginFilePath, err.Error())

--- a/pkg/datatype/event.go
+++ b/pkg/datatype/event.go
@@ -155,7 +155,7 @@ type EventType string
 const (
 	// EventSchedulingDecisionScheduled EventType = "sys.scheduler.decision.scheduled"
 	EventJobStatusSuspended     EventType = "sys.scheduler.status.job.suspended"
-	EventGoalStatusNew          EventType = "sys.scheduler.status.goal.new"
+	EventGoalStatusSubmitted    EventType = "sys.scheduler.status.goal.submitted"
 	EventGoalStatusUpdated      EventType = "sys.scheduler.status.goal.updated"
 	EventGoalStatusReceived     EventType = "sys.scheduler.status.goal.received"
 	EventGoalStatusReceivedBulk EventType = "sys.scheduler.status.goal.received.bulk"

--- a/pkg/datatype/sciencegoal.go
+++ b/pkg/datatype/sciencegoal.go
@@ -75,6 +75,14 @@ func (g *ScienceGoal) ShowMyScienceGoal(nodeName string) *ScienceGoal {
 	}
 }
 
+// GetSubjectNodes returns a list of nodes subject to run this science goal
+func (g *ScienceGoal) GetSubjectNodes() (nodes []string) {
+	for _, subGoal := range g.SubGoals {
+		nodes = append(nodes, subGoal.Name)
+	}
+	return
+}
+
 // SubGoal structs node-specific goal along with conditions and rules
 type SubGoal struct {
 	Name         string    `json:"name" yaml:"name"`


### PR DESCRIPTION
- `--no-push-notification` disables the push notification through `api/v1/goals/{NODE}/stream`. By default, cloud scheduler uses the endpoint for nodes as a client to get goal updates as jobs being submitted and updated by users.