### PR TITLE
SAGE-1437: Add pluginctl build command

### DIFF
--- a/cmd/pluginctl/cmd/build.go
+++ b/cmd/pluginctl/cmd/build.go
@@ -22,14 +22,6 @@ func init() {
 	flags := cmd.Flags()
 	tag := flags.String("t", "", "image tag")
 
-	/*
-		example
-		# cloned plugin-test-pipeline, cd'd in, made small code change
-		docker build -t 10.31.81.1:5000/seanshahkarami/plugin-test-pipeline .
-		docker push -10.31.81.1:5000/seanshahkarami/plugin-test-pipeline
-		pluginctl run -n plugin-test-pipeline 10.31.81.1:5000/seanshahkarami/plugin-test-pipeline
-	*/
-
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		path, err := filepath.Abs(args[0])
 		if err != nil {

--- a/cmd/pluginctl/cmd/build.go
+++ b/cmd/pluginctl/cmd/build.go
@@ -31,7 +31,7 @@ pluginctl run $(pluginctl build my-plugin)`,
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		path, err := filepath.Abs(args[0])
 		if err != nil {
-			return fmt.Errorf("invalid path: %s", err.Error())
+			return fmt.Errorf("invalid plugin path: %s", err.Error())
 		}
 		name := filepath.Base(path)
 		image := fmt.Sprintf("%s/%s/%s", registry, namespace, name)

--- a/cmd/pluginctl/cmd/build.go
+++ b/cmd/pluginctl/cmd/build.go
@@ -13,42 +13,38 @@ import (
 )
 
 func init() {
+	const registry = "10.31.81.1:5000"
+	const namespace = "local"
+
 	cmd := &cobra.Command{
 		Use:   "build PLUGIN_DIR",
 		Short: "Build plugin from directory",
 		Args:  cobra.ExactArgs(1),
 	}
 
-	flags := cmd.Flags()
-	tag := flags.String("t", "", "image tag")
-
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		path, err := filepath.Abs(args[0])
 		if err != nil {
 			return fmt.Errorf("invalid path: %s", err.Error())
 		}
-
 		name := filepath.Base(path)
-
-		if *tag == "" {
-			*tag = fmt.Sprintf("10.31.81.1:5000/local/%s", name)
-		}
+		image := fmt.Sprintf("%s/%s/%s", registry, namespace, name)
 
 		// build and push to local registry. all output goes to stderr to allow easy piping
 		ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 
-		if err := runCommandContextStderr(ctx, "docker", "build", "-t", *tag, path); err != nil {
+		if err := runCommandContextStderr(ctx, "docker", "build", "-t", image, path); err != nil {
 			return err
 		}
 
-		if err := runCommandContextStderr(ctx, "docker", "push", *tag); err != nil {
+		if err := runCommandContextStderr(ctx, "docker", "push", image); err != nil {
 			return err
 		}
 
-		fmt.Fprintf(os.Stderr, "successfully build image!\n\n")
+		fmt.Fprintf(os.Stderr, "Successfully built plugin\n\n")
 
 		// print tag to stdout to allow piping into other commands: pluginctl run -n my-plugin $(pluginctl build .)
-		fmt.Printf("%s\n", *tag)
+		fmt.Printf("%s\n", image)
 
 		return nil
 	}

--- a/cmd/pluginctl/cmd/build.go
+++ b/cmd/pluginctl/cmd/build.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "build PLUGIN_DIR",
+		Short: "Build plugin from directory",
+		Args:  cobra.ExactArgs(1),
+	}
+
+	flags := cmd.Flags()
+	tag := flags.String("t", "", "image tag")
+
+	/*
+		example
+		# cloned plugin-test-pipeline, cd'd in, made small code change
+		docker build -t 10.31.81.1:5000/seanshahkarami/plugin-test-pipeline .
+		docker push -10.31.81.1:5000/seanshahkarami/plugin-test-pipeline
+		pluginctl run -n plugin-test-pipeline 10.31.81.1:5000/seanshahkarami/plugin-test-pipeline
+	*/
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		path, err := filepath.Abs(args[0])
+		if err != nil {
+			return fmt.Errorf("invalid path: %s", err.Error())
+		}
+
+		name := filepath.Base(path)
+
+		if *tag == "" {
+			*tag = fmt.Sprintf("10.31.81.1:5000/waggle/%s", name)
+		}
+
+		ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+
+		if err := runCommandContextStderr(ctx, "docker", "build", "-t", *tag, path); err != nil {
+			return err
+		}
+
+		if err := runCommandContextStderr(ctx, "docker", "push", *tag); err != nil {
+			return err
+		}
+
+		fmt.Fprintf(os.Stderr, "successfully build image!\n\n")
+
+		// print tag to stdout to make pipeable into other commands: pluginctl run -n my-plugin $(pluginctl build .)
+		fmt.Printf("%s\n", *tag)
+
+		return nil
+	}
+
+	rootCmd.AddCommand(cmd)
+}
+
+func runCommandContextStderr(ctx context.Context, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/cmd/pluginctl/cmd/build.go
+++ b/cmd/pluginctl/cmd/build.go
@@ -18,8 +18,14 @@ func init() {
 
 	cmd := &cobra.Command{
 		Use:   "build PLUGIN_DIR",
-		Short: "Build plugin from directory",
-		Args:  cobra.ExactArgs(1),
+		Short: "Build plugin",
+		Long:  "Build a plugin contained in a directory.",
+		Example: `# clone plugin repo
+git clone https://github.com/my-username/my-plugin
+
+# build and run plugin in cloned directory
+pluginctl run $(pluginctl build my-plugin)`,
+		Args: cobra.ExactArgs(1),
 	}
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/pluginctl/cmd/build.go
+++ b/cmd/pluginctl/cmd/build.go
@@ -31,7 +31,7 @@ func init() {
 		name := filepath.Base(path)
 
 		if *tag == "" {
-			*tag = fmt.Sprintf("10.31.81.1:5000/waggle/%s", name)
+			*tag = fmt.Sprintf("10.31.81.1:5000/local/%s", name)
 		}
 
 		// build and push to local registry. all output goes to stderr to allow easy piping

--- a/cmd/pluginctl/cmd/build.go
+++ b/cmd/pluginctl/cmd/build.go
@@ -42,6 +42,7 @@ func init() {
 			*tag = fmt.Sprintf("10.31.81.1:5000/waggle/%s", name)
 		}
 
+		// build and push to local registry. all output goes to stderr to allow easy piping
 		ctx, _ := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 
 		if err := runCommandContextStderr(ctx, "docker", "build", "-t", *tag, path); err != nil {
@@ -54,7 +55,7 @@ func init() {
 
 		fmt.Fprintf(os.Stderr, "successfully build image!\n\n")
 
-		// print tag to stdout to make pipeable into other commands: pluginctl run -n my-plugin $(pluginctl build .)
+		// print tag to stdout to allow piping into other commands: pluginctl run -n my-plugin $(pluginctl build .)
 		fmt.Printf("%s\n", *tag)
 
 		return nil


### PR DESCRIPTION
This PR adds a pluginctl build command which allows building to a local registry.

I'm opening the PR early as it implements the minimal functionality needed for the dev workflow. Some open questions are still:
* Do we want multiple arch builds? (NX and RPi share arch and OS, so may not be needed immediately.)
* Do we want any other flags? (Right now, you can specify an explicit tag with -t. Should we extended this? Remove it?)
* Use sage.yaml?