### PR TITLE
Cloud scheduler subscribing scheduling events from nodes

### DIFF
--- a/cmd/sesctl/cmd/create.go
+++ b/cmd/sesctl/cmd/create.go
@@ -6,54 +6,51 @@ import (
 	"net/url"
 
 	"github.com/spf13/cobra"
-	"github.com/waggle-sensor/edge-scheduler/pkg/interfacing"
 )
 
 func init() {
-	var (
-		filePath string
-	)
 	cmdCreate := &cobra.Command{
 		Use:              "create JOB_NAME [FLAGS]",
 		Short:            "Create a job for submission",
 		TraverseChildren: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			r := interfacing.NewHTTPRequest(serverHostString)
-			if filePath != "" {
-				resp, err := r.RequestPostFromFile("api/v1/create", filePath)
-				if err != nil {
-					return err
+			createFunc := func(r *JobRequest) error {
+				if r.FilePath != "" {
+					resp, err := r.handler.RequestPostFromFile("api/v1/create", r.FilePath)
+					if err != nil {
+						return err
+					}
+					body, err := r.handler.ParseJSONHTTPResponse(resp)
+					if err != nil {
+						return err
+					}
+					blob, _ := json.MarshalIndent(body, "", " ")
+					fmt.Printf("%s\n", string(blob))
+				} else {
+					if len(args) < 1 {
+						return fmt.Errorf("Please specify job name")
+					}
+					name := args[0]
+					q, err := url.ParseQuery("name=" + name)
+					if err != nil {
+						return err
+					}
+					resp, err := r.handler.RequestGet("api/v1/create", q, r.Headers)
+					if err != nil {
+						return err
+					}
+					body, err := r.handler.ParseJSONHTTPResponse(resp)
+					if err != nil {
+						return err
+					}
+					fmt.Printf("%v", body)
 				}
-				body, err := r.ParseJSONHTTPResponse(resp)
-				if err != nil {
-					return err
-				}
-				blob, _ := json.MarshalIndent(body, "", " ")
-				fmt.Printf("%s\n", string(blob))
-			} else {
-				if len(args) < 1 {
-					return fmt.Errorf("Please specify job name")
-				}
-				name := args[0]
-				q, err := url.ParseQuery("name=" + name)
-				if err != nil {
-					return err
-				}
-				resp, err := r.RequestGet("api/v1/create", q)
-				if err != nil {
-					return err
-				}
-				body, err := r.ParseJSONHTTPResponse(resp)
-				if err != nil {
-					return err
-				}
-				fmt.Printf("%v", body)
-				// logger.Debug.Printf("%s", body["name"])
+				return nil
 			}
-			return nil
+			return jobRequest.Run(createFunc)
 		},
 	}
 	flags := cmdCreate.Flags()
-	flags.StringVarP(&filePath, "file-path", "f", "", "Path to job file")
+	flags.StringVarP(&jobRequest.FilePath, "file-path", "f", "", "Path to job file")
 	rootCmd.AddCommand(cmdCreate)
 }

--- a/cmd/sesctl/cmd/edit.go
+++ b/cmd/sesctl/cmd/edit.go
@@ -6,46 +6,42 @@ import (
 	"net/url"
 
 	"github.com/spf13/cobra"
-	"github.com/waggle-sensor/edge-scheduler/pkg/interfacing"
 )
 
 func init() {
 	// TODO: edit does not yet support inline editing of jobs like "kubectl edit"
-	var (
-		filePath string
-	)
 	cmdEdit := &cobra.Command{
 		Use:              "edit JOB_ID",
 		Short:            "Modify an existing job",
 		TraverseChildren: true,
 		Args:             cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) < 1 {
-				return fmt.Errorf("JOB_ID must be specified.")
+			jobRequest.JobID = args[0]
+			editFunc := func(r *JobRequest) error {
+				if r.FilePath != "" {
+					q, err := url.ParseQuery("&id=" + fmt.Sprint(args[0]))
+					if err != nil {
+						return err
+					}
+					resp, err := r.handler.RequestPostFromFileWithQueries("api/v1/edit", r.FilePath, q)
+					if err != nil {
+						return err
+					}
+					body, err := r.handler.ParseJSONHTTPResponse(resp)
+					if err != nil {
+						return err
+					}
+					blob, _ := json.MarshalIndent(body, "", " ")
+					fmt.Printf("%s\n", string(blob))
+				} else {
+					return fmt.Errorf("Interactive job editing is not supported. Please use -f to change job.")
+				}
+				return nil
 			}
-			r := interfacing.NewHTTPRequest(serverHostString)
-			if filePath != "" {
-				q, err := url.ParseQuery("&id=" + fmt.Sprint(args[0]))
-				if err != nil {
-					return err
-				}
-				resp, err := r.RequestPostFromFileWithQueries("api/v1/edit", filePath, q)
-				if err != nil {
-					return err
-				}
-				body, err := r.ParseJSONHTTPResponse(resp)
-				if err != nil {
-					return err
-				}
-				blob, _ := json.MarshalIndent(body, "", " ")
-				fmt.Printf("%s\n", string(blob))
-			} else {
-				return fmt.Errorf("Interactive job editing is not supported. Please use -f to change job.")
-			}
-			return nil
+			return jobRequest.Run(editFunc)
 		},
 	}
 	flags := cmdEdit.Flags()
-	flags.StringVarP(&filePath, "file-path", "f", "", "Path to the job file")
+	flags.StringVarP(&jobRequest.FilePath, "file-path", "f", "", "Path to the job file")
 	rootCmd.AddCommand(cmdEdit)
 }

--- a/cmd/sesctl/cmd/rm.go
+++ b/cmd/sesctl/cmd/rm.go
@@ -7,41 +7,38 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
-	"github.com/waggle-sensor/edge-scheduler/pkg/interfacing"
 )
 
 func init() {
-	var (
-		suspend bool
-		force   bool
-	)
 	cmdRm := &cobra.Command{
 		Use:              "rm [FLAGS] JOB_ID",
 		Short:            "Remove or suspend a job",
 		TraverseChildren: true,
 		Args:             cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			jobID := args[0]
-			r := interfacing.NewHTTPRequest(serverHostString)
-			q, err := url.ParseQuery("id=" + jobID + "&suspend=" + strconv.FormatBool(suspend) + "&force=" + strconv.FormatBool(force))
-			if err != nil {
-				return err
+			jobRequest.JobID = args[0]
+			rmFunc := func(r *JobRequest) error {
+				q, err := url.ParseQuery("id=" + r.JobID + "&suspend=" + strconv.FormatBool(r.Suspend) + "&force=" + strconv.FormatBool(r.Force))
+				if err != nil {
+					return err
+				}
+				resp, err := r.handler.RequestGet(fmt.Sprintf("api/v1/jobs/%s/rm", r.JobID), q, r.Headers)
+				if err != nil {
+					return err
+				}
+				body, err := r.handler.ParseJSONHTTPResponse(resp)
+				if err != nil {
+					return err
+				}
+				blob, _ := json.MarshalIndent(body, "", " ")
+				fmt.Printf("%s\n", string(blob))
+				return nil
 			}
-			resp, err := r.RequestGet(fmt.Sprintf("api/v1/jobs/%s/rm", jobID), q)
-			if err != nil {
-				return err
-			}
-			body, err := r.ParseJSONHTTPResponse(resp)
-			if err != nil {
-				return err
-			}
-			blob, _ := json.MarshalIndent(body, "", " ")
-			fmt.Printf("%s\n", string(blob))
-			return nil
+			return jobRequest.Run(rmFunc)
 		},
 	}
 	flags := cmdRm.Flags()
-	flags.BoolVarP(&suspend, "suspend", "s", false, "Suspend the job")
-	flags.BoolVarP(&force, "force", "f", false, "Remove or suspend the job forcefully")
+	flags.BoolVarP(&jobRequest.Suspend, "suspend", "s", false, "Suspend the job")
+	flags.BoolVarP(&jobRequest.Force, "force", "f", false, "Remove or suspend the job forcefully")
 	rootCmd.AddCommand(cmdRm)
 }

--- a/cmd/sesctl/cmd/sesctl.go
+++ b/cmd/sesctl/cmd/sesctl.go
@@ -10,19 +10,11 @@ import (
 )
 
 var (
-	Version          string
-	debug            bool
-	name             string
-	node             string
-	privileged       bool
-	job              string
-	selectorStr      string
-	followLog        bool
-	entrypoint       string
-	stdin            bool
-	tty              bool
-	serverHostString string
+	Version string
+	debug   bool
 )
+
+var jobRequest = &JobRequest{}
 
 func getenv(key string, def string) string {
 	if val, ok := os.LookupEnv(key); ok {
@@ -32,23 +24,11 @@ func getenv(key string, def string) string {
 }
 
 func init() {
-	var rootCmd = &cobra.Command{
-		Use: "sesctl [FLAGS] [COMMANDS]",
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if !debug {
-				logger.Debug.SetOutput(io.Discard)
-			}
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("SAGE edge scheduler client version: %s\n", Version)
-			fmt.Printf("sesctl --help for more information\n")
-		},
-		// ValidArgs: []string{"deploy", "logs"},
-	}
 	// To prevent printing the usage when commands end with an error
 	// rootCmd.SilenceUsage = true
 	rootCmd.SilenceErrors = true
-	rootCmd.PersistentFlags().StringVar(&serverHostString, "server", getenv("SES_HOST", "http://localhost:9770"), "path to the kubeconfig file")
+	rootCmd.PersistentFlags().StringVar(&jobRequest.ServerHostString, "server", getenv("SES_HOST", "http://localhost:9770"), "Path to the kubeconfig file")
+	rootCmd.PersistentFlags().StringVar(&jobRequest.UserToken, "token", getenv("SES_USER_TOKEN", ""), "User token")
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "flag to debug")
 }
 
@@ -58,6 +38,12 @@ var rootCmd = &cobra.Command{
 		if !debug {
 			logger.Debug.SetOutput(io.Discard)
 		}
+	},
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if jobRequest.UserToken == "" {
+			return fmt.Errorf("Must provide a valid token")
+		}
+		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("SAGE edge scheduler client version: %s\n", Version)

--- a/cmd/sesctl/cmd/stat.go
+++ b/cmd/sesctl/cmd/stat.go
@@ -9,110 +9,108 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/waggle-sensor/edge-scheduler/pkg/datatype"
-	"github.com/waggle-sensor/edge-scheduler/pkg/interfacing"
 )
 
 func init() {
-	var (
-		jobID   string
-		outPath string
-		showAll bool
-	)
+	var showAll bool
 	cmdStat := &cobra.Command{
 		Use:              "stat [FLAGS]",
 		Short:            "List jobs",
 		TraverseChildren: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			r := interfacing.NewHTTPRequest(serverHostString)
-			if jobID != "" {
-				resp, err := r.RequestGet(fmt.Sprintf("api/v1/jobs/%s/status", jobID), nil)
-				if err != nil {
-					return err
-				}
-				body, err := r.ParseJSONHTTPResponse(resp)
-				if err != nil {
-					return err
-				}
-				if blob, exist := body[jobID]; exist {
-					jobBlob, err := json.MarshalIndent(blob, "", "  ")
+			statFunc := func(r *JobRequest) error {
+				if r.JobID != "" {
+					resp, err := r.handler.RequestGet(fmt.Sprintf("api/v1/jobs/%s/status", r.JobID), nil, r.Headers)
 					if err != nil {
 						return err
 					}
-					if outPath != "" {
-						err := ioutil.WriteFile(outPath, jobBlob, 0644)
+					body, err := r.handler.ParseJSONHTTPResponse(resp)
+					if err != nil {
+						return err
+					}
+					if blob, exist := body[r.JobID]; exist {
+						jobBlob, err := json.MarshalIndent(blob, "", "  ")
 						if err != nil {
 							return err
 						}
+						if r.OutPath != "" {
+							err := ioutil.WriteFile(r.OutPath, jobBlob, 0644)
+							if err != nil {
+								return err
+							}
+						} else {
+							var job datatype.Job
+							err := json.Unmarshal(jobBlob, &job)
+							if err != nil {
+								return err
+							}
+							fmt.Print(printJob(&job))
+						}
+						return nil
 					} else {
-						var job datatype.Job
-						err := json.Unmarshal(jobBlob, &job)
-						if err != nil {
-							return err
-						}
-						fmt.Print(printJob(&job))
+						return fmt.Errorf("Failed to get the job %q: Job does not exist", r.JobID)
 					}
 				} else {
-					return fmt.Errorf("Failed to get the job %q: Job does not exist", jobID)
-				}
-			} else {
-				resp, err := r.RequestGet("api/v1/jobs", nil)
-				if err != nil {
-					return err
-				}
-				body, err := r.ParseJSONHTTPResponse(resp)
-				if err != nil {
-					return err
-				}
-				var (
-					maxLengthID     int = 5
-					maxLengthName   int = 26
-					maxLengthUser   int = 8
-					maxLengthStatus int = len("complete")
-					maxAge          int = 5
-					// maxLengthStartTime int = len("mm/dd/yyyy hh:MM:ss")
-					// maxLengthDuration  int = len("mm/dd/yyyy hh:MM:ss")
-				)
-				formattedList := fmt.Sprintf("%-*s%-*s%-*s%-*s%-*s\n", maxLengthID+3, "JOB_ID", maxLengthName+3, "NAME", maxLengthUser+3, "USER", maxLengthStatus+3, "STATUS", maxAge+3, "AGE")
-				formattedList += strings.Repeat("=", len(formattedList)) + "\n"
-				for _, blob := range body {
-					jobBlob, err := json.Marshal(blob)
+					resp, err := r.handler.RequestGet("api/v1/jobs", nil, r.Headers)
 					if err != nil {
 						return err
 					}
-					var job *datatype.Job
-					err = json.Unmarshal(jobBlob, &job)
+					body, err := r.handler.ParseJSONHTTPResponse(resp)
 					if err != nil {
 						return err
 					}
-					if !showAll {
-						if job.Status == datatype.JobRemoved || job.Status == datatype.JobComplete {
-							continue
+					var (
+						maxLengthID     int = 5
+						maxLengthName   int = 26
+						maxLengthUser   int = 8
+						maxLengthStatus int = len("complete")
+						maxAge          int = 5
+						// maxLengthStartTime int = len("mm/dd/yyyy hh:MM:ss")
+						// maxLengthDuration  int = len("mm/dd/yyyy hh:MM:ss")
+					)
+					formattedList := fmt.Sprintf("%-*s%-*s%-*s%-*s%-*s\n", maxLengthID+3, "JOB_ID", maxLengthName+3, "NAME", maxLengthUser+3, "USER", maxLengthStatus+3, "STATUS", maxAge+3, "AGE")
+					formattedList += strings.Repeat("=", len(formattedList)) + "\n"
+					for _, blob := range body {
+						jobBlob, err := json.Marshal(blob)
+						if err != nil {
+							return err
+						}
+						var job *datatype.Job
+						err = json.Unmarshal(jobBlob, &job)
+						if err != nil {
+							return err
+						}
+						if !showAll {
+							if job.Status == datatype.JobRemoved || job.Status == datatype.JobComplete {
+								continue
+							}
+						}
+						var name string
+						if len(job.Name) > maxLengthName {
+							name = job.Name[:maxLengthName-1] + "..."
+						} else {
+							name = job.Name
+						}
+						switch job.Status {
+						case datatype.JobSubmitted, datatype.JobRunning, datatype.JobComplete:
+							t := time.Now().UTC()
+							age := t.Sub(job.LastUpdated).Round(1 * time.Second)
+							formattedList += fmt.Sprintf("%-*s%-*s%-*s%-*s%-*s\n", maxLengthID+3, job.JobID, maxLengthName+3, name, maxLengthUser+3, job.User, maxLengthStatus+3, job.Status, maxAge, age)
+							break
+						default:
+							formattedList += fmt.Sprintf("%-*s%-*s%-*s%-*s%-*s\n", maxLengthID+3, job.JobID, maxLengthName+3, name, maxLengthUser+3, job.User, maxLengthStatus+3, job.Status, maxAge, "-")
 						}
 					}
-					var name string
-					if len(job.Name) > maxLengthName {
-						name = job.Name[:maxLengthName-1] + "..."
-					} else {
-						name = job.Name
-					}
-					switch job.Status {
-					case datatype.JobSubmitted, datatype.JobRunning, datatype.JobComplete:
-						t := time.Now().UTC()
-						age := t.Sub(job.LastUpdated).Round(1 * time.Second)
-						formattedList += fmt.Sprintf("%-*s%-*s%-*s%-*s%-*s\n", maxLengthID+3, job.JobID, maxLengthName+3, name, maxLengthUser+3, job.User, maxLengthStatus+3, job.Status, maxAge, age)
-						break
-					default:
-						formattedList += fmt.Sprintf("%-*s%-*s%-*s%-*s%-*s\n", maxLengthID+3, job.JobID, maxLengthName+3, name, maxLengthUser+3, job.User, maxLengthStatus+3, job.Status, maxAge, "-")
-					}
+					fmt.Printf("%s", formattedList)
 				}
-				fmt.Printf("%s", formattedList)
+				return nil
 			}
-			return nil
+			return jobRequest.Run(statFunc)
 		},
 	}
 	flags := cmdStat.Flags()
-	flags.StringVarP(&jobID, "job-id", "j", "", "Job ID")
-	flags.StringVarP(&outPath, "out", "o", "", "Path to save output")
+	flags.StringVarP(&jobRequest.JobID, "job-id", "j", "", "Job ID")
+	flags.StringVarP(&jobRequest.OutPath, "out", "o", "", "Path to save output")
 	flags.BoolVarP(&showAll, "show-all", "A", false, "Show all jobs including removed and completed jobs")
 	rootCmd.AddCommand(cmdStat)
 }

--- a/cmd/sesctl/cmd/util.go
+++ b/cmd/sesctl/cmd/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/waggle-sensor/edge-scheduler/pkg/datatype"
+	"github.com/waggle-sensor/edge-scheduler/pkg/interfacing"
 )
 
 func printJob(j *datatype.Job) (ret string) {
@@ -21,6 +22,13 @@ Job Starttime: %s
 		j.Status,
 		j.LastUpdated.UTC().String(),
 	)
+	if len(j.NotificationOn) > 0 {
+		ret += fmt.Sprintf(`
+Notification to %s
+On %v
+`,
+			j.Email, j.NotificationOn)
+	}
 	if j.ScienceGoal != nil {
 		ret += fmt.Sprintf(`
 ===== SCHEDULING DETAILS =====
@@ -50,4 +58,33 @@ Total number of nodes %d
 
 	// )
 	return ret
+}
+
+type JobRequest struct {
+	ServerHostString string
+	handler          *interfacing.HTTPRequest
+	UserToken        string
+	JobID            string
+	OutPath          string            // for saving response into a file
+	DryRun           bool              // dry-run of job submission
+	FilePath         string            // for loading job description from a file
+	Suspend          bool              // for suspending a job
+	Force            bool              // for making the request forceful
+	Headers          map[string]string // additional headers for request
+}
+
+func (r *JobRequest) open() {
+	r.handler = interfacing.NewHTTPRequest(r.ServerHostString)
+}
+
+func (r *JobRequest) Run(f func(*JobRequest) error) error {
+	if r.handler == nil {
+		r.open()
+	}
+	// TODO: The token may use different name other than Sage
+	r.Headers = map[string]string{
+		"Accept":        "applications/json",
+		"Authorization": fmt.Sprintf("Sage %s", r.UserToken),
+	}
+	return f(r)
 }

--- a/pkg/cloudscheduler/api_server.go
+++ b/pkg/cloudscheduler/api_server.go
@@ -141,7 +141,7 @@ func (api *APIServer) handlerEditJob(w http.ResponseWriter, r *http.Request) {
 	queries := r.URL.Query()
 	if _, exist := queries["id"]; exist {
 		jobID := queries.Get("id")
-		_, err := api.cloudScheduler.GoalManager.GetJob(jobID)
+		oldJob, err := api.cloudScheduler.GoalManager.GetJob(jobID)
 		if err != nil {
 			response := datatype.NewAPIMessageBuilder().AddError(err.Error()).Build()
 			respondJSON(w, http.StatusBadRequest, response.ToJson())
@@ -163,6 +163,10 @@ func (api *APIServer) handlerEditJob(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			updatedJob.JobID = jobID
+			// Remove science goal of old Job if exists
+			if oldJob.ScienceGoal != nil {
+				api.cloudScheduler.GoalManager.RemoveScienceGoal(oldJob.ScienceGoal.ID)
+			}
 			api.cloudScheduler.GoalManager.UpdateJob(updatedJob, false)
 			response := datatype.NewAPIMessageBuilder().AddEntity("job_id", jobID).AddEntity("status", datatype.JobDrafted)
 			respondJSON(w, http.StatusOK, response.Build().ToJson())

--- a/pkg/cloudscheduler/authenticate.go
+++ b/pkg/cloudscheduler/authenticate.go
@@ -1,0 +1,33 @@
+package cloudscheduler
+
+type Authenticator interface {
+	Authenticate(string) (bool, error)
+}
+
+func NewAuthenticator(authServerURL string) Authenticator {
+	// If no auth server is given we will use a fake auth granting any request
+	if authServerURL == "" {
+		return &FakeAuthenticator{}
+	} else {
+		return &RealAuthenticator{
+			AuthServerURL: authServerURL,
+		}
+	}
+}
+
+type FakeAuthenticator struct {
+}
+
+func (auth *FakeAuthenticator) Authenticate(token string) (bool, error) {
+	return true, nil
+}
+
+type RealAuthenticator struct {
+	AuthServerURL string
+}
+
+func (auth *RealAuthenticator) Authenticate(token string) (bool, error) {
+	// req := interfacing.NewHTTPRequest(auth.AuthServerURL)
+	// req.
+	return true, nil
+}

--- a/pkg/cloudscheduler/metrics_collector.go
+++ b/pkg/cloudscheduler/metrics_collector.go
@@ -1,5 +1,10 @@
 package cloudscheduler
 
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/waggle-sensor/edge-scheduler/pkg/datatype"
+)
+
 type JobsMetric struct {
 	CountSubmitted int
 	CountRunning   int
@@ -8,4 +13,69 @@ type JobsMetric struct {
 
 func (m *JobsMetric) GrantTotal() int {
 	return m.CountSubmitted + m.CountRunning + m.CountCompleted
+}
+
+type MetricsCollector struct {
+	cs             *CloudScheduler
+	jobsGrandTotal *prometheus.Desc
+	jobsTotal      *prometheus.Desc
+}
+
+func NewMetricsCollector(cs *CloudScheduler) *MetricsCollector {
+	return &MetricsCollector{
+		cs: cs,
+		jobsGrandTotal: prometheus.NewDesc(
+			"scheduler_jobs_total",
+			"Total number of jobs in the scheduler",
+			nil,
+			nil),
+		jobsTotal: prometheus.NewDesc(
+			"scheduler_jobs_count",
+			"Number of jobs per status",
+			[]string{"status"},
+			nil),
+	}
+}
+
+func (mc *MetricsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- mc.jobsGrandTotal
+	ch <- mc.jobsTotal
+}
+
+func (mc *MetricsCollector) Collect(ch chan<- prometheus.Metric) {
+	var m JobsMetric
+	// TODO: Do we count removed jobs for the completed jobs?
+	for _, j := range mc.cs.GoalManager.GetJobs() {
+		switch j.Status {
+		case datatype.JobCreated, datatype.JobDrafted, datatype.JobSuspended, datatype.JobSubmitted:
+			m.CountSubmitted += 1
+		case datatype.JobRunning:
+			m.CountRunning += 1
+		case datatype.JobComplete, datatype.JobRemoved:
+			m.CountCompleted += 1
+		}
+	}
+	ch <- prometheus.MustNewConstMetric(
+		mc.jobsGrandTotal,
+		prometheus.GaugeValue,
+		float64(m.GrantTotal()),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		mc.jobsTotal,
+		prometheus.GaugeValue,
+		float64(m.CountSubmitted),
+		"submitted",
+	)
+	ch <- prometheus.MustNewConstMetric(
+		mc.jobsTotal,
+		prometheus.GaugeValue,
+		float64(m.CountRunning),
+		"running",
+	)
+	ch <- prometheus.MustNewConstMetric(
+		mc.jobsTotal,
+		prometheus.GaugeValue,
+		float64(m.CountCompleted),
+		"completed",
+	)
 }

--- a/pkg/datatype/event.go
+++ b/pkg/datatype/event.go
@@ -127,6 +127,18 @@ func (e *Event) ToString() string {
 	return string(e.Type)
 }
 
+func NewEventBuilderFromWaggleMessage(m *WaggleMessage) (*EventBuilder, error) {
+	builder := NewEventBuilder(EventType(m.Name))
+	builder.e.Timestamp = m.Timestamp
+	var body map[string]string
+	err := json.Unmarshal([]byte(m.Value.(string)), &body)
+	if err != nil {
+		return nil, err
+	}
+	builder.e.Meta = body
+	return builder, nil
+}
+
 // ToWaggleMessage converts an Event into a Waggle message that can be sent through Waggle infrastructure.
 //
 // A few points to make in this conversion is,

--- a/pkg/datatype/event_test.go
+++ b/pkg/datatype/event_test.go
@@ -1,17 +1,36 @@
 package datatype
 
-// func TestEvent(t *testing.T) {
-// 	newEvent := NewSimpleEvent(EventSchedulingDecisionPromoted, "hello world")
-// 	expected := `{"event":"sys.scheduler.decision.protomoted","meta":{},"value":"hello world"}`
-// 	// expected, err := json.marshal(map[string]interface{}{
-// 	// 	"event": string(EventSchedulingDecision),
-// 	// 	"meta": map[string]string{},
-// 	// 	"value": "hello world",
-// 	// })
-// 	blob, err := newEvent.encodeToJson()
-// 	if err != nil {
-// 		t.Errorf("Error in encoding the event: %q", err.Error())
-// 	} else {
-// 		fmt.Printf("%s %v", expected, string(blob))
-// 	}
-// }
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEventWaggleConversion(t *testing.T) {
+	tests := map[string]struct {
+		Type    string
+		Payload map[string]string
+	}{
+		"simple": {
+			Type: string(EventPluginStatusLaunched),
+			Payload: map[string]string{
+				"test": "great",
+			},
+		},
+	}
+	for _, test := range tests {
+		e := NewEventBuilder(EventType(test.Type))
+		for k, v := range test.Payload {
+			e.AddEntry(k, v)
+		}
+		msg := e.Build()
+		waggleMsg := msg.ToWaggleMessage()
+		unWaggleMsgBuilder, _ := NewEventBuilderFromWaggleMessage(waggleMsg)
+		unWaggleMsg := unWaggleMsgBuilder.Build()
+		if unWaggleMsg.Type != EventType(test.Type) {
+			t.Errorf("Type mismatch: wanted %s, got %s", test.Type, unWaggleMsg.Type)
+		}
+		if !reflect.DeepEqual(test.Payload, unWaggleMsg.Meta) {
+			t.Errorf("Type mismatch: wanted %v, got %v", test.Payload, unWaggleMsg.Meta)
+		}
+	}
+}

--- a/pkg/datatype/job.go
+++ b/pkg/datatype/job.go
@@ -15,7 +15,7 @@ const (
 	JobDrafted   JobStatus = "Drafted"
 	JobSubmitted JobStatus = "Submitted"
 	JobRunning   JobStatus = "Running"
-	JobComplete  JobStatus = "Complete"
+	JobComplete  JobStatus = "Completed"
 	JobSuspended JobStatus = "Suspended"
 	JobRemoved   JobStatus = "Removed"
 )
@@ -25,6 +25,8 @@ type Job struct {
 	Name            string                 `json:"name" yaml:"name"`
 	JobID           string                 `json:"job_id" yaml:"jobID"`
 	User            string                 `json:"user" yaml:"user"`
+	Email           string                 `json:"email" yaml:"email"`
+	NotificationOn  []JobStatus            `json:"notification_on" yaml:"notificationOn"`
 	Plugins         []*Plugin              `json:"plugins,omitempty" yaml:"plugins,omitempty"`
 	NodeTags        []string               `json:"node_tags" yaml:"nodeTags"`
 	Nodes           map[string]interface{} `json:"nodes" yaml:"nodes"`
@@ -42,6 +44,11 @@ func NewJob(name string, user string, jobID string) *Job {
 		User:  user,
 		Nodes: make(map[string]interface{}),
 	}
+}
+
+func (j *Job) SetNotification(email string, on []JobStatus) {
+	j.Email = email
+	j.NotificationOn = on
 }
 
 func (j *Job) UpdateStatus(newStatus JobStatus) {

--- a/pkg/datatype/wagglemessage.go
+++ b/pkg/datatype/wagglemessage.go
@@ -31,12 +31,15 @@ func Dump(message *WaggleMessage) []byte {
 	return raw
 }
 
-func Load(raw []byte) *WaggleMessage {
+func Load(raw []byte) (*WaggleMessage, error) {
 	var message WaggleMessage
-	json.Unmarshal(raw, &message)
+	err := json.Unmarshal(raw, &message)
+	if err != nil {
+		return nil, err
+	}
 	if message.Enc == "b64" {
 		v, _ := b64.StdEncoding.DecodeString(message.Value.(string))
 		message.Value = v
 	}
-	return &message
+	return &message, nil
 }

--- a/pkg/datatype/wagglemessage_test.go
+++ b/pkg/datatype/wagglemessage_test.go
@@ -62,7 +62,7 @@ func TestWaggleMessageValueTypes(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			originalMessage := NewMessage(tc.message.Name, tc.message.Value, tc.message.Timestamp, tc.message.Meta)
 			encodedMessage := Dump(originalMessage)
-			decodedMessage := Load(encodedMessage)
+			decodedMessage, _ := Load(encodedMessage)
 			switch originalMessage.Value.(type) {
 			case float64:
 				if originalMessage.Value != decodedMessage.Value {

--- a/pkg/interfacing/rmq.go
+++ b/pkg/interfacing/rmq.go
@@ -1,44 +1,77 @@
 package interfacing
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"io/ioutil"
+	"time"
 
 	"github.com/streadway/amqp"
 	"github.com/waggle-sensor/edge-scheduler/pkg/datatype"
 	"github.com/waggle-sensor/edge-scheduler/pkg/logger"
+	"gopkg.in/cenkalti/backoff.v1"
 )
 
 type RabbitMQHandler struct {
 	RabbitmqURI      string
 	rabbitmqUsername string
 	rabbitmqPassword string
+	cacertPath       string
 	rabbitmqConn     *amqp.Connection
 	rabbitmqChan     *amqp.Channel
 	appID            string
 }
 
-func NewRabbitMQHandler(rabbitmqURI string, rabbitmqUsername string, rabbitmqPassword string, appID string) *RabbitMQHandler {
+func NewRabbitMQHandler(rabbitmqURI string, rabbitmqUsername string, rabbitmqPassword string, cacertPath string, appID string) *RabbitMQHandler {
 	return &RabbitMQHandler{
 		RabbitmqURI:      rabbitmqURI,
 		rabbitmqUsername: rabbitmqUsername,
 		rabbitmqPassword: rabbitmqPassword,
+		cacertPath:       cacertPath,
 		appID:            appID,
 	}
 }
 
 func (rh *RabbitMQHandler) Connect() error {
-	amqpAddress := fmt.Sprintf("amqp://%s:%s@%s", rh.rabbitmqUsername, rh.rabbitmqPassword, rh.RabbitmqURI)
-	logger.Debug.Printf("Connecting to %s...", rh.RabbitmqURI)
-	conn, err := amqp.Dial(amqpAddress)
-	if err != nil {
-		return err
+	// If cacert is given it attempts TLS connection
+	if rh.cacertPath == "" {
+		caCert, err := ioutil.ReadFile(rh.cacertPath)
+		if err != nil {
+			return err
+		}
+		rootCAs := x509.NewCertPool()
+		rootCAs.AppendCertsFromPEM(caCert)
+		tlsConf := &tls.Config{
+			RootCAs:            rootCAs,
+			InsecureSkipVerify: true,
+		}
+		amqpAddress := fmt.Sprintf("amqps://%s:%s@%s", rh.rabbitmqUsername, rh.rabbitmqPassword, rh.RabbitmqURI)
+		logger.Debug.Printf("Connecting to %s...", rh.RabbitmqURI)
+		conn, err := amqp.DialTLS(amqpAddress, tlsConf)
+		if err != nil {
+			return err
+		}
+		rh.rabbitmqConn = conn
+		ch, err := conn.Channel()
+		if err != nil {
+			return err
+		}
+		rh.rabbitmqChan = ch
+	} else {
+		amqpAddress := fmt.Sprintf("amqp://%s:%s@%s", rh.rabbitmqUsername, rh.rabbitmqPassword, rh.RabbitmqURI)
+		logger.Debug.Printf("Connecting to %s...", rh.RabbitmqURI)
+		conn, err := amqp.Dial(amqpAddress)
+		if err != nil {
+			return err
+		}
+		rh.rabbitmqConn = conn
+		ch, err := conn.Channel()
+		if err != nil {
+			return err
+		}
+		rh.rabbitmqChan = ch
 	}
-	rh.rabbitmqConn = conn
-	ch, err := conn.Channel()
-	if err != nil {
-		return err
-	}
-	rh.rabbitmqChan = ch
 	return nil
 }
 
@@ -61,7 +94,13 @@ func (rh *RabbitMQHandler) CreateExchange(exchange string) error {
 	return err
 }
 
-func (rh *RabbitMQHandler) DeclareQueueAndConnectToExchange(exchangeName string, queueName string) (*amqp.Queue, error) {
+func (rh *RabbitMQHandler) DeclareQueueAndConnectToExchange(exchangeName string, queueName string, topicToSubscribe string) (*amqp.Queue, error) {
+	if rh.rabbitmqConn == nil || rh.rabbitmqConn.IsClosed() {
+		err := rh.Connect()
+		if err != nil {
+			return nil, err
+		}
+	}
 	q, err := rh.rabbitmqChan.QueueDeclare(
 		queueName, // name
 		true,      // durable
@@ -74,9 +113,9 @@ func (rh *RabbitMQHandler) DeclareQueueAndConnectToExchange(exchangeName string,
 		return nil, err
 	}
 	err = rh.rabbitmqChan.QueueBind(
-		q.Name,       // queue name
-		q.Name,       // routing key
-		exchangeName, // exchange
+		q.Name,           // queue name
+		topicToSubscribe, // routing key
+		exchangeName,     // exchange
 		false,
 		nil)
 	if err != nil {
@@ -150,4 +189,44 @@ func (rh *RabbitMQHandler) GetReceiver(queueName string) (<-chan amqp.Delivery, 
 		nil,       // args
 	)
 	return msgs, err
+}
+
+// SubscribeEvents subscribes scheduling events from target exchange
+// it will attempt to reconnect if connection is closed
+func (rh *RabbitMQHandler) SubscribeEvents(exchange string, queueName string, ch chan *datatype.Event) error {
+	operation := func() error {
+		q, err := rh.DeclareQueueAndConnectToExchange(exchange, queueName, "sys.scheduler.#")
+		if err != nil {
+			return err
+		}
+		c, err := rh.GetReceiver(q.Name)
+		if err != nil {
+			return err
+		}
+		for msg := range c {
+			if waggleMessage, err := datatype.Load(msg.Body); err == nil {
+				eventBuilder, err := datatype.NewEventBuilderFromWaggleMessage(waggleMessage)
+				if err != nil {
+					logger.Debug.Printf("Failed to parse %v: %s", waggleMessage, err.Error())
+				} else {
+					if vsn, exist := waggleMessage.Meta["vsn"]; exist {
+						eventBuilder.AddEntry("vsn", vsn)
+					}
+					event := eventBuilder.Build()
+					ch <- &event
+				}
+			}
+		}
+		return nil
+	}
+	go func() {
+		for {
+			err := backoff.Retry(operation, backoff.NewExponentialBackOff())
+			logger.Error.Printf("Failed to subscribe %q: %s", exchange, err.Error())
+			time.Sleep(5 * time.Second)
+			logger.Info.Printf("Retrying to connect to %q in 5 seconds...", exchange)
+		}
+
+	}()
+	return nil
 }

--- a/pkg/nodescheduler/builder.go
+++ b/pkg/nodescheduler/builder.go
@@ -62,6 +62,7 @@ func (nsb *NodeSchedulerBuilder) AddGoalManager(appID string) *NodeSchedulerBuil
 			nsb.nodeScheduler.Config.RabbitmqURI,
 			nsb.nodeScheduler.Config.RabbitmqUsername,
 			nsb.nodeScheduler.Config.RabbitmqPassword,
+			"",
 			appID),
 		)
 	}
@@ -105,6 +106,7 @@ func (nsb *NodeSchedulerBuilder) AddLoggerToBeehive(appID string) *NodeScheduler
 		nsb.nodeScheduler.Config.RabbitmqURI,
 		nsb.nodeScheduler.Config.RabbitmqUsername,
 		nsb.nodeScheduler.Config.RabbitmqPassword,
+		"",
 		appID)
 	return nsb
 }


### PR DESCRIPTION
New feature:
- cloud scheduler attempts to connect to Beehive-RabbitMQ to receive scheduling events sent from nodes. For now it only checks if active science goals are received by recipient nodes
- sesctl now requires a user token to perform any scheduling action. This can be obtained from the auth service. Please ask system administrator for details