### PR TITLE
Change auth/access server

### DIFF
--- a/cmd/cloudscheduler/main.go
+++ b/cmd/cloudscheduler/main.go
@@ -36,7 +36,7 @@ func main() {
 	flag.StringVar(&config.RabbitmqPassword, "rabbitmq-password", getenv("RABBITMQ_PASSWORD", "guest"), "RabbitMQ management password")
 	flag.BoolVar(&config.PushNotification, "push-notification", true, "Enable HTTP push notification for science goals")
 	flag.StringVar(&config.AuthServerURL, "auth-server-url", getenv("AUTH_URL", ""), "Authentication server URL")
-	flag.StringVar(&config.AuthPassword, "auth-password", getenv("AUTH_PASSWORD", ""), "Password to query in authentication server")
+	flag.StringVar(&config.AuthToken, "auth-token", getenv("AUTH_TOKEN", ""), "TOKEN to query to authentication server")
 	flag.Parse()
 	logger.Info.Printf("Cloud scheduler (%s) starts...", config.Name)
 	if configPath != "" {

--- a/pkg/cloudscheduler/api_server.go
+++ b/pkg/cloudscheduler/api_server.go
@@ -285,6 +285,13 @@ func (api *APIServer) handlerSubmitJobs(w http.ResponseWriter, r *http.Request) 
 				return
 			}
 			jobID := api.cloudScheduler.GoalManager.AddJob(newJob)
+			err = api.authenticator.UpdatePermissionTableForUser(user)
+			if err != nil {
+				response := datatype.NewAPIMessageBuilder()
+				response.AddError(err.Error())
+				respondJSON(w, http.StatusInternalServerError, response.Build().ToJson())
+				return
+			}
 			errorList := api.cloudScheduler.ValidateJobAndCreateScienceGoal(jobID, user, flagDryRun)
 			if len(errorList) > 0 {
 				response := datatype.NewAPIMessageBuilder().
@@ -317,7 +324,12 @@ func (api *APIServer) handlerJobs(w http.ResponseWriter, r *http.Request) {
 	}
 	if r.Method == http.MethodGet {
 		response := datatype.NewAPIMessageBuilder()
-		jobs := api.cloudScheduler.GoalManager.GetJobs(user.GetUserName())
+		var jobs []*datatype.Job
+		if user.Auth.IsSuperUser {
+			jobs = api.cloudScheduler.GoalManager.GetJobs("")
+		} else {
+			jobs = api.cloudScheduler.GoalManager.GetJobs(user.GetUserName())
+		}
 		for _, job := range jobs {
 			response.AddEntity(job.JobID, job)
 		}
@@ -340,6 +352,11 @@ func (api *APIServer) handlerJobStatus(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			response.AddError(err.Error())
 			respondJSON(w, http.StatusBadRequest, response.Build().ToJson())
+			return
+		}
+		if user.Auth.IsSuperUser {
+			response.AddEntity(vars["id"], job)
+			respondJSON(w, http.StatusOK, response.Build().ToJson())
 			return
 		}
 		if job.User != user.GetUserName() {
@@ -516,9 +533,9 @@ func (api *APIServer) authenticate(r *http.Request) (*User, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Authentication failed: %s", err.Error())
 	}
-	if user.Auth.Active == false {
-		return user, fmt.Errorf("User %q is inactive. Please contact administrator.", user.GetUserName())
-	}
+	// if user.Auth.Active == false {
+	// 	return user, fmt.Errorf("User %q is inactive. Please contact administrator.", user.GetUserName())
+	// }
 	return user, nil
 }
 

--- a/pkg/cloudscheduler/builder.go
+++ b/pkg/cloudscheduler/builder.go
@@ -18,7 +18,7 @@ type CloudSchedulerConfig struct {
 	DataDir            string `json:"data_dir,omitempty" yaml:"dataDir,omitempty"`
 	PushNotification   bool   `json:"push_notification" yaml:"PushNotification"`
 	AuthServerURL      string `json:"auth_server_url" yaml:"authServerURL"`
-	AuthPassword       string `json:"auth_password" yaml:"authPassword"`
+	AuthToken          string `json:"auth_token" yaml:"authToken"`
 }
 
 type CloudSchedulerBuilder struct {
@@ -54,7 +54,7 @@ func (csb *CloudSchedulerBuilder) AddAPIServer() *CloudSchedulerBuilder {
 		port:                   csb.cloudScheduler.Config.Port,
 		enablePushNotification: csb.cloudScheduler.Config.PushNotification,
 		subscribers:            make(map[string]map[chan *datatype.Event]bool),
-		authenticator:          NewAuthenticator(csb.cloudScheduler.Config.AuthServerURL, csb.cloudScheduler.Config.AuthPassword),
+		authenticator:          NewAuthenticator(csb.cloudScheduler.Config.AuthServerURL, csb.cloudScheduler.Config.AuthToken),
 	}
 	return csb
 }


### PR DESCRIPTION
- the cloud scheduler is updated with the new auth/access server to fetch user information and user permission table.
- if the user is "superuser" `/jobs/list` returns all jobs, and `jobs/<<id>>/status` also returns the job even if the job owner is different