### PR TITLE
SAGE-1619: re-enable GPU pod access with K3S v1.25.4

### DIFF
--- a/pkg/nodescheduler/resourcemanager.go
+++ b/pkg/nodescheduler/resourcemanager.go
@@ -412,6 +412,11 @@ func (rm *ResourceManager) createPodTemplateSpecForPlugin(plugin *datatype.Plugi
 				},
 			},
 		},
+		// Perform all NVidia runtime mounts from /etc/nvi/dia-container-runtime/host-files-for-container.d
+		{
+			Name:  "NVIDIA_REQUIRE_JETPACK",
+			Value: "csv-mounts=all",
+		},
 	}
 
 	for k, v := range plugin.PluginSpec.Env {


### PR DESCRIPTION
Without this environment variable definition only the 'l4t.csv' file listed mounts are performed when using the NVidia runtime when launching pods. This causes for many core (i.e. including /usr/local/cuda/) mounts to not exist in the launched pod causing for GPU access to fail. This change informs the runtime to perform the mounts form all '*.csv' files (as was done with v1.20.2 K3S).