### PR TITLE
SAGE-1699: Added resource request / limit to init container.

### DIFF
--- a/pkg/nodescheduler/resourcemanager.go
+++ b/pkg/nodescheduler/resourcemanager.go
@@ -540,6 +540,15 @@ func (rm *ResourceManager) createPodTemplateSpecForPlugin(plugin *datatype.Plugi
 					},
 				},
 			},
+			Resources: apiv1.ResourceRequirements{
+				Requests: apiv1.ResourceList{
+					apiv1.ResourceCPU:    resource.MustParse("100m"),
+					apiv1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+				Limits: apiv1.ResourceList{
+					apiv1.ResourceMemory: resource.MustParse("50Mi"),
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
This PR addresses an issue where init containers may not get scheduled due to having too high of a default memory request.