### PR TITLE
Fixed the memory leak in node scheduler

### DIFF
--- a/pkg/interfacing/http.go
+++ b/pkg/interfacing/http.go
@@ -183,6 +183,10 @@ func (r *HTTPRequest) Subscribe(streamPath string, ch chan *datatype.Event, keep
 		for {
 			err := backoff.Retry(operation, backoff.NewExponentialBackOff())
 			logger.Error.Printf("Failed to subscribe %q: %s", streamPath, err.Error())
+			if !keepRetry {
+				logger.Info.Printf("keepRetry is false. Closing...")
+				break
+			}
 			time.Sleep(5 * time.Second)
 			logger.Info.Printf("Retrying to connect to %q in 5 seconds...", streamPath)
 		}

--- a/pkg/nodescheduler/api_server.go
+++ b/pkg/nodescheduler/api_server.go
@@ -6,18 +6,14 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"net/http/pprof"
+
+	// "net/http/pprof"
 	"strconv"
 
 	"github.com/gorilla/mux"
 	"github.com/waggle-sensor/edge-scheduler/pkg/datatype"
 	"github.com/waggle-sensor/edge-scheduler/pkg/logger"
 	// "github.com/urfave/negroni"
-)
-
-var (
-	// Channels for IPC
-	chanFromMeasure = make(chan RMQMessage)
 )
 
 type APIServer struct {
@@ -27,12 +23,8 @@ type APIServer struct {
 	nodeScheduler *NodeScheduler
 }
 
-func NewAPIServer() *APIServer {
-	return &APIServer{}
-}
-
 func (api *APIServer) Run() {
-	api_address_port := "0.0.0.0:8080"
+	api_address_port := fmt.Sprintf("0.0.0.0:%d", api.port)
 	logger.Info.Printf("API server starts at %q...", api_address_port)
 	api.mainRouter = mux.NewRouter()
 	r := api.mainRouter
@@ -40,9 +32,9 @@ func (api *APIServer) Run() {
 		fmt.Fprintln(w, `{"id": "Node Scheduler (`+api.nodeScheduler.NodeID+`)", "version":"`+api.version+`"}`)
 	})
 	api_route := r.PathPrefix("/api/v1").Subrouter()
-	mux := http.NewServeMux()
-	mux.HandleFunc("/debug/pprof", pprof.Index)
-	go http.ListenAndServe(":18080", nil)
+	// mux := http.NewServeMux()
+	// mux.HandleFunc("/debug/pprof", pprof.Index)
+	// go http.ListenAndServe(":18080", nil)
 	api_route.Handle("/kb/rules", http.HandlerFunc(api.handlerRules)).Methods(http.MethodGet, http.MethodPost)
 	api_route.Handle("/kb/senses", http.HandlerFunc(api.handlerSenses)).Methods(http.MethodGet, http.MethodPost, http.MethodDelete)
 	api_route.Handle("/goals", http.HandlerFunc(api.handlerGoals)).Methods(http.MethodGet, http.MethodPost, http.MethodPut)
@@ -69,7 +61,6 @@ func (api *APIServer) handlerRules(w http.ResponseWriter, r *http.Request) {
 	case http.MethodPost:
 		r.ParseForm()
 		clause := r.Form.Get("clause")
-		log.Printf(clause)
 		respondJSON(w, http.StatusOK, clause)
 	}
 }

--- a/pkg/nodescheduler/builder.go
+++ b/pkg/nodescheduler/builder.go
@@ -78,6 +78,7 @@ func (nsb *NodeSchedulerBuilder) AddAPIServer() *NodeSchedulerBuilder {
 	nsb.nodeScheduler.APIServer = &APIServer{
 		version:       nsb.nodeScheduler.Config.Version,
 		nodeScheduler: nsb.nodeScheduler,
+		port:          8080,
 	}
 	return nsb
 }

--- a/pkg/nodescheduler/nodescheduler.go
+++ b/pkg/nodescheduler/nodescheduler.go
@@ -1,7 +1,6 @@
 package nodescheduler
 
 import (
-	"encoding/json"
 	"net/url"
 	"sync"
 	"time"
@@ -72,7 +71,7 @@ func (ns *NodeScheduler) Configure() (err error) {
 
 // Run handles communications between components for scheduling
 func (ns *NodeScheduler) Run() {
-	go ns.ResourceManager.Run()
+	// go ns.ResourceManager.Run()
 	go ns.APIServer.Run()
 	ruleCheckingTicker := time.NewTicker(10 * time.Second)
 	for {
@@ -220,14 +219,14 @@ func (ns *NodeScheduler) Run() {
 			case datatype.EventGoalStatusReceivedBulk:
 				// A goal set is received. We add or update the goals.
 				logger.Debug.Printf("A bulk goal is received")
-				data := event.GetEntry("goals")
-				var goals []datatype.ScienceGoal
-				err := json.Unmarshal([]byte(data), &goals)
-				if err != nil {
-					logger.Error.Printf("Failed to load bulk goals %q", err.Error())
-				} else {
-					ns.handleBulkGoals(goals)
-				}
+				// data := event.GetEntry("goals")
+				// var goals []datatype.ScienceGoal
+				// err := json.Unmarshal([]byte(data), &goals)
+				// if err != nil {
+				// 	logger.Error.Printf("Failed to load bulk goals %q", err.Error())
+				// } else {
+				// 	ns.handleBulkGoals(goals)
+				// }
 			}
 		}
 	}

--- a/pkg/nodescheduler/nodescheduler.go
+++ b/pkg/nodescheduler/nodescheduler.go
@@ -1,6 +1,7 @@
 package nodescheduler
 
 import (
+	"encoding/json"
 	"net/url"
 	"sync"
 	"time"
@@ -71,7 +72,7 @@ func (ns *NodeScheduler) Configure() (err error) {
 
 // Run handles communications between components for scheduling
 func (ns *NodeScheduler) Run() {
-	// go ns.ResourceManager.Run()
+	go ns.ResourceManager.Run()
 	go ns.APIServer.Run()
 	ruleCheckingTicker := time.NewTicker(10 * time.Second)
 	for {
@@ -219,14 +220,14 @@ func (ns *NodeScheduler) Run() {
 			case datatype.EventGoalStatusReceivedBulk:
 				// A goal set is received. We add or update the goals.
 				logger.Debug.Printf("A bulk goal is received")
-				// data := event.GetEntry("goals")
-				// var goals []datatype.ScienceGoal
-				// err := json.Unmarshal([]byte(data), &goals)
-				// if err != nil {
-				// 	logger.Error.Printf("Failed to load bulk goals %q", err.Error())
-				// } else {
-				// 	ns.handleBulkGoals(goals)
-				// }
+				data := event.GetEntry("goals")
+				var goals []datatype.ScienceGoal
+				err := json.Unmarshal([]byte(data), &goals)
+				if err != nil {
+					logger.Error.Printf("Failed to load bulk goals %q", err.Error())
+				} else {
+					ns.handleBulkGoals(goals)
+				}
 			}
 		}
 	}

--- a/pkg/nodescheduler/resourcemanager.go
+++ b/pkg/nodescheduler/resourcemanager.go
@@ -1322,9 +1322,10 @@ func (w *AdvancedWatcher) runWatcher() error {
 	if err != nil {
 		return fmt.Errorf("Failed to get watcher from Kubernetes")
 	}
+	chanEvent := watcher.ResultChan()
 	for {
 		select {
-		case e, ok := <-watcher.ResultChan():
+		case e, ok := <-chanEvent:
 			if !ok {
 				return fmt.Errorf("Watcher is closed")
 			} else {

--- a/pkg/nodescheduler/resourcemanager.go
+++ b/pkg/nodescheduler/resourcemanager.go
@@ -948,6 +948,7 @@ func (rm *ResourceManager) LaunchAndWatchPlugin(plugin *datatype.Plugin) {
 			return
 		}
 		chanEvent := watcher.ResultChan()
+		defer watcher.Stop()
 		for event := range chanEvent {
 			logger.Debug.Printf("Plugin %s received an event %s", job.Name, event.Type)
 			switch event.Type {


### PR DESCRIPTION
The node scheduler had a memory leak that caused the scheduler container out-of-memory killed by Kubernetes whenever it exceeds given memory limit.

With the go profiling tool, we found that the Kubernetes Watcher in a goroutine that manages a plugin didn't get released when we terminate the goroutine, after the plugin exits.

The PR has the release code to close the goroutine cleanly.