### PR TITLE
Upgrade go-setup action to leverage cache support

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -5,12 +5,11 @@ jobs:
     name: CI/CD
     runs-on: ubuntu-20.04
     steps:
+      - uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: "^1.19"
-      - name: Checkout
-        uses: actions/checkout@v2
+          go-version-file: "go.mod"
       - name: Run tests
         run: go test -v ./...
       - name: Get release version
@@ -65,7 +64,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to Github Package Registry
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
This PR is a small quality of life improvement.

I realized that later versions of the `setup-go` action automatically can configure build caching. This should speed building the user tools for releases when minor changes are being iterated on.