### PR TITLE
a bug fix and permission override

### DIFF
--- a/cmd/sesctl/cmd/edit.go
+++ b/cmd/sesctl/cmd/edit.go
@@ -21,7 +21,7 @@ func init() {
 			editFunc := func(r *JobRequest) error {
 				subPathString := path.Join(cloudscheduler.API_V1_VERSION, cloudscheduler.API_PATH_JOB_EDIT)
 				if r.FilePath != "" {
-					q, err := url.ParseQuery("&id=" + fmt.Sprint(args[0]))
+					q, err := url.ParseQuery("&id=" + fmt.Sprint(args[0]) + "&override=" + fmt.Sprint(r.Override))
 					if err != nil {
 						return err
 					}
@@ -44,5 +44,6 @@ func init() {
 	}
 	flags := cmdEdit.Flags()
 	flags.StringVarP(&jobRequest.FilePath, "file-path", "f", "", "Path to the job file")
+	flags.BoolVar(&jobRequest.Override, "override", false, "Attempt to override the permission")
 	rootCmd.AddCommand(cmdEdit)
 }

--- a/cmd/sesctl/cmd/rm.go
+++ b/cmd/sesctl/cmd/rm.go
@@ -20,7 +20,10 @@ func init() {
 			jobRequest.JobID = args[0]
 			rmFunc := func(r *JobRequest) error {
 				subPathString := path.Join(cloudscheduler.API_V1_VERSION, cloudscheduler.API_PATH_JOB_REMOVE_REGEX)
-				q, err := url.ParseQuery("suspend=" + strconv.FormatBool(r.Suspend) + "&force=" + strconv.FormatBool(r.Force))
+				q, err := url.ParseQuery(
+					"suspend=" + strconv.FormatBool(r.Suspend) +
+						"&force=" + strconv.FormatBool(r.Force) +
+						"&override=" + fmt.Sprint(r.Override))
 				if err != nil {
 					return err
 				}
@@ -41,5 +44,6 @@ func init() {
 	flags := cmdRm.Flags()
 	flags.BoolVarP(&jobRequest.Suspend, "suspend", "s", false, "Suspend the job")
 	flags.BoolVarP(&jobRequest.Force, "force", "f", false, "Remove or suspend the job forcefully")
+	flags.BoolVar(&jobRequest.Override, "override", false, "Attempt to override the permission")
 	rootCmd.AddCommand(cmdRm)
 }

--- a/cmd/sesctl/cmd/submit.go
+++ b/cmd/sesctl/cmd/submit.go
@@ -18,7 +18,7 @@ func init() {
 			submitFunc := func(r *JobRequest) error {
 				subPathString := path.Join(cloudscheduler.API_V1_VERSION, cloudscheduler.API_PATH_JOB_SUBMIT)
 				if r.JobID != "" {
-					q, err := url.ParseQuery("id=" + r.JobID + "&dryrun=" + fmt.Sprint(r.DryRun))
+					q, err := url.ParseQuery("id=" + r.JobID + "&dryrun=" + fmt.Sprint(r.DryRun) + "&override=" + fmt.Sprint(r.Override))
 					if err != nil {
 						return err
 					}
@@ -57,5 +57,6 @@ func init() {
 	flags.StringVarP(&jobRequest.JobID, "job-id", "j", "", "Job ID")
 	flags.BoolVarP(&jobRequest.DryRun, "dry-run", "", false, "Dry run the job")
 	flags.StringVarP(&jobRequest.FilePath, "file-path", "f", "", "Path to the job file")
+	flags.BoolVar(&jobRequest.Override, "override", false, "Attempt to override the permission")
 	rootCmd.AddCommand(cmdSubmit)
 }

--- a/cmd/sesctl/cmd/util.go
+++ b/cmd/sesctl/cmd/util.go
@@ -93,6 +93,7 @@ type JobRequest struct {
 	FilePath         string            // for loading job description from a file
 	Suspend          bool              // for suspending a job
 	Force            bool              // for making the request forceful
+	Override         bool              // attempting to override the permission
 	Headers          map[string]string // additional headers for request
 }
 

--- a/pkg/cloudscheduler/api_server.go
+++ b/pkg/cloudscheduler/api_server.go
@@ -245,6 +245,7 @@ func (api *APIServer) handlerEditJob(w http.ResponseWriter, r *http.Request) {
 			if oldJob.ScienceGoal != nil {
 				api.cloudScheduler.GoalManager.RemoveScienceGoal(oldJob.ScienceGoal.ID)
 			}
+			updatedJob.Drafted()
 			api.cloudScheduler.GoalManager.UpdateJob(updatedJob, false)
 			response := datatype.NewAPIMessageBuilder().AddEntity("job_id", jobID).AddEntity("state", datatype.JobDrafted)
 			respondJSON(w, http.StatusOK, response.Build().ToJson())

--- a/pkg/cloudscheduler/api_server.go
+++ b/pkg/cloudscheduler/api_server.go
@@ -216,12 +216,6 @@ func (api *APIServer) handlerEditJob(w http.ResponseWriter, r *http.Request) {
 			respondJSON(w, http.StatusBadRequest, response.ToJson())
 			return
 		}
-		// If the job is not created by the user, raise an error
-		if oldJob.User != user.GetUserName() {
-			response := datatype.NewAPIMessageBuilder().AddError(fmt.Sprintf("User %s does not have access to the job", user.GetUserName())).Build()
-			respondJSON(w, http.StatusBadRequest, response.ToJson())
-			return
-		}
 		defer r.Body.Close()
 		// TODO: the API always assumes that the body contains job content
 		updatedJob := datatype.NewJob("", "", "")
@@ -231,26 +225,44 @@ func (api *APIServer) handlerEditJob(w http.ResponseWriter, r *http.Request) {
 			response := datatype.NewAPIMessageBuilder().AddError(err.Error()).Build()
 			respondJSON(w, http.StatusBadRequest, response.ToJson())
 			return
-		} else {
-			err = yaml.Unmarshal(blob, &updatedJob)
-			if err != nil {
-				response := datatype.NewAPIMessageBuilder().AddError(err.Error()).Build()
+		}
+		err = yaml.Unmarshal(blob, &updatedJob)
+		if err != nil {
+			response := datatype.NewAPIMessageBuilder().AddError(err.Error()).Build()
+			respondJSON(w, http.StatusBadRequest, response.ToJson())
+			return
+		}
+		updatedJob.JobID = jobID
+		if oldJob.User != user.GetUserName() {
+			logger.Info.Printf("user %q does not own the job %s", user.GetUserName(), jobID)
+			if queries.Get("override") == "true" {
+				logger.Info.Printf("user %q is attempting to override job %q owned by %s", user.GetUserName(), jobID, oldJob.User)
+				if user.Auth.IsSuperUser {
+					logger.Info.Printf("user %q is a super user. overriding permitted", user.GetUserName())
+					// keep the original user name
+					updatedJob.User = oldJob.User
+				} else {
+					response := datatype.NewAPIMessageBuilder().AddError(fmt.Sprintf("User %s does not have permission to override to the job", user.GetUserName())).Build()
+					respondJSON(w, http.StatusBadRequest, response.ToJson())
+					return
+				}
+			} else {
+				response := datatype.NewAPIMessageBuilder().AddError(fmt.Sprintf("User %s does not have access to the job", user.GetUserName())).Build()
 				respondJSON(w, http.StatusBadRequest, response.ToJson())
 				return
 			}
-			updatedJob.JobID = jobID
-			// Make sure the job ownder is the owner from the authentication
+		} else {
 			updatedJob.User = user.GetUserName()
-			// Remove science goal of old Job if exists
-			if oldJob.ScienceGoal != nil {
-				api.cloudScheduler.GoalManager.RemoveScienceGoal(oldJob.ScienceGoal.ID)
-			}
-			updatedJob.Drafted()
-			api.cloudScheduler.GoalManager.UpdateJob(updatedJob, false)
-			response := datatype.NewAPIMessageBuilder().AddEntity("job_id", jobID).AddEntity("state", datatype.JobDrafted)
-			respondJSON(w, http.StatusOK, response.Build().ToJson())
-			return
 		}
+		// Remove science goal of old Job if exists
+		if oldJob.ScienceGoal != nil {
+			api.cloudScheduler.GoalManager.RemoveScienceGoal(oldJob.ScienceGoal.ID)
+		}
+		updatedJob.Drafted()
+		api.cloudScheduler.GoalManager.UpdateJob(updatedJob, false)
+		response := datatype.NewAPIMessageBuilder().AddEntity("job_id", jobID).AddEntity("state", datatype.JobDrafted)
+		respondJSON(w, http.StatusOK, response.Build().ToJson())
+		return
 	} else {
 		response := datatype.NewAPIMessageBuilder().AddError("job_id is required").Build()
 		respondJSON(w, http.StatusBadRequest, response.ToJson())
@@ -426,6 +438,7 @@ func (api *APIServer) handlerJobRemove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	vars := mux.Vars(r)
+	queries := r.URL.Query()
 	jobID := vars["id"]
 	job, err := api.cloudScheduler.GoalManager.GetJob(jobID)
 	if err != nil {
@@ -434,11 +447,22 @@ func (api *APIServer) handlerJobRemove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if job.User != user.GetUserName() {
-		response.AddError(fmt.Sprintf("User %s does not have permission to remove the job %s", user.GetUserName(), jobID))
-		respondJSON(w, http.StatusBadRequest, response.Build().ToJson())
-		return
+		logger.Info.Printf("user %q does not own the job %s", user.GetUserName(), jobID)
+		if queries.Get("override") == "true" {
+			logger.Info.Printf("user %q is attempting to override job %q owned by %s", user.GetUserName(), jobID, job.User)
+			if user.Auth.IsSuperUser {
+				logger.Info.Printf("user %q is a super user. overriding permitted", user.GetUserName())
+			} else {
+				response := datatype.NewAPIMessageBuilder().AddError(fmt.Sprintf("User %s does not have permission to override to the job", user.GetUserName())).Build()
+				respondJSON(w, http.StatusBadRequest, response.ToJson())
+				return
+			}
+		} else {
+			response := datatype.NewAPIMessageBuilder().AddError(fmt.Sprintf("user %q is not the owner of job %q", user.GetUserName(), jobID)).Build()
+			respondJSON(w, http.StatusBadRequest, response.ToJson())
+			return
+		}
 	}
-	queries := r.URL.Query()
 	// Suspend the job instead of removal if suspend flag is given
 	suspend := queries.Get("suspend")
 	if suspend == "true" {

--- a/pkg/cloudscheduler/cloudscheduler.go
+++ b/pkg/cloudscheduler/cloudscheduler.go
@@ -200,6 +200,10 @@ func (cs *CloudScheduler) ValidateJobAndCreateScienceGoal(jobID string, user *Us
 		return errorList
 	}
 	logger.Info.Printf("Updating science goal for JOB ID %q", jobID)
+	if job.ScienceGoal != nil {
+		logger.Info.Printf("job ID %q has an existing goal %q. dropping it first...", jobID, job.ScienceGoal.ID)
+		cs.GoalManager.RemoveScienceGoal(job.ScienceGoal.ID)
+	}
 	job.ScienceGoal = scienceGoalBuilder.Build()
 	if dryrun {
 		cs.GoalManager.UpdateJob(job, false)

--- a/pkg/datatype/job.go
+++ b/pkg/datatype/job.go
@@ -106,6 +106,10 @@ func (j *Job) Created() {
 	j.UpdateState(JobCreated)
 }
 
+func (j *Job) Drafted() {
+	j.UpdateState(JobDrafted)
+}
+
 func (j *Job) Submitted() {
 	j.UpdateState(JobSubmitted)
 }


### PR DESCRIPTION
- Fixed a bug when user submits a job multiple times. Cloud scheduler drops science goal if it exists before creating a new science goal for new submission
- superuser now can edit / remove / re-submit others jobs. When submitting, only re-submission is possible for permission override.