### PR TITLE
Bug fix and pluginctl profile get --since

### DIFF
--- a/cmd/pluginctl/cmd/log.go
+++ b/cmd/pluginctl/cmd/log.go
@@ -31,8 +31,6 @@ var cmdLog = &cobra.Command{
 		if err != nil {
 			return
 		}
-		// name = args[0]
-		// logger.Debug.Printf("args: %v", args)
 		c := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
 		c.KubeConfig = &kubeconfig
 		for i := 0; i < len(os.Args); i++ {
@@ -47,55 +45,47 @@ var cmdLog = &cobra.Command{
 			ConfigFlags:   c,
 			IOStreams:     genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr},
 		})
-		// k.SetArgs([]string{"exec", "-n", "default", "-it", "node-influxdb-77bb74f689-nr5zm", "--", "/bin/date"})
 		return k.Execute()
-		// pluginCtl, err := pluginctl.NewPluginCtl(kubeconfig)
+
+		// c := make(chan os.Signal, 1)
+		// signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+		// go func() {
+		// 	watcher, err := pluginCtl.ResourceManager.WatchPod(name, pluginCtl.ResourceManager.Namespace, 0)
+		// 	if err != nil {
+		// 		logger.Error.Printf("%q", err.Error())
+		// 		c <- nil
+		// 	}
+		// 	chanEvent := watcher.ResultChan()
+		// 	for event := range chanEvent {
+		// 		switch event.Type {
+		// 		case watch.Modified:
+		// 			_pod := event.Object.(*v1.Pod)
+		// 			switch _pod.Status.Phase {
+		// 			case v1.PodSucceeded, v1.PodFailed:
+		// 				logger.Debug.Printf("%s: %s", event.Type, _pod.Status.Phase)
+		// 				c <- nil
+		// 			}
+		// 		case watch.Deleted:
+		// 			logger.Error.Printf("Plugin deleted unexpectedly")
+		// 			c <- nil
+		// 		}
+		// 	}
+		// }()
+		// printLogFunc, terminateLog, err := pluginCtl.PrintLog(name, false)
 		// if err != nil {
-		// 	return
-		// }
-		// printLogFunc, terminateLog, err := pluginCtl.PrintLog(name, followLog)
-		// if err != nil {
-		// 	return
+		// 	return err
 		// } else {
-		// 	c := make(chan os.Signal, 1)
-		// 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 		// 	go printLogFunc()
 		// 	for {
 		// 		select {
 		// 		case <-c:
-		// 			logger.Debug.Println("Log terminated from user")
-		// 			return
+		// 			logger.Debug.Println("Log terminated from user side")
+		// 			return nil
 		// 		case <-terminateLog:
 		// 			logger.Debug.Println("Log terminated from handler")
-		// 			return
+		// 			return nil
 		// 		}
 		// 	}
-		// }
-
-		// podLog, err := pluginctl.Log(name, followLog)
-		// if err != nil {
-		// 	logger.Error.Println("%s", err.Error())
-		// } else {
-		// 	c := make(chan os.Signal, 1)
-		// 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-		// 	go func() {
-		// 		buf := make([]byte, 2000)
-		// 		for {
-		// 			numBytes, err := podLog.Read(buf)
-		// 			if numBytes == 0 {
-		// 				break
-		// 			}
-		// 			if err == io.EOF {
-		// 				break
-		// 			} else if err != nil {
-		// 				// return err
-		// 			}
-		// 			fmt.Println(string(buf[:numBytes]))
-		// 		}
-		// 		c <- nil
-		// 	}()
-		// 	<-c
-		// 	podLog.Close()
 		// }
 	},
 }

--- a/pkg/nodescheduler/api_server.go
+++ b/pkg/nodescheduler/api_server.go
@@ -4,11 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 
 	// "net/http/pprof"
-	"strconv"
 
 	"github.com/gorilla/mux"
 	"github.com/waggle-sensor/edge-scheduler/pkg/datatype"
@@ -35,72 +33,16 @@ func (api *APIServer) Run() {
 	// mux := http.NewServeMux()
 	// mux.HandleFunc("/debug/pprof", pprof.Index)
 	// go http.ListenAndServe(":18080", nil)
-	api_route.Handle("/kb/rules", http.HandlerFunc(api.handlerRules)).Methods(http.MethodGet, http.MethodPost)
-	api_route.Handle("/kb/senses", http.HandlerFunc(api.handlerSenses)).Methods(http.MethodGet, http.MethodPost, http.MethodDelete)
 	api_route.Handle("/goals", http.HandlerFunc(api.handlerGoals)).Methods(http.MethodGet, http.MethodPost, http.MethodPut)
+	api_route.Handle("/schedule", http.HandlerFunc(api.handlerSchedule)).Methods(http.MethodGet, http.MethodPost, http.MethodPut)
 	// api_route.Handle("/status/queue/waiting", http.HandlerFunc(api.handlerGoals)).Methods(http.MethodGet, http.MethodPost, http.MethodPut)
 	logger.Info.Fatalln(http.ListenAndServe(api_address_port, r))
 }
 
-func respondJSON(w http.ResponseWriter, statusCode int, data interface{}) {
+func respondJSON(w http.ResponseWriter, statusCode int, data []byte) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
-
-	// json.NewEncoder(w).Encode(data)
-	s, err := json.MarshalIndent(data, "", "  ")
-	if err == nil {
-		w.Write(s)
-	}
-}
-
-func (api *APIServer) handlerRules(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodGet:
-		clauses := ""
-		respondJSON(w, http.StatusOK, clauses)
-	case http.MethodPost:
-		r.ParseForm()
-		clause := r.Form.Get("clause")
-		respondJSON(w, http.StatusOK, clause)
-	}
-}
-
-func (api *APIServer) handlerSenses(w http.ResponseWriter, r *http.Request) {
-
-	switch r.Method {
-	case http.MethodGet:
-		queries := r.URL.Query()
-		if _, exist := queries["key"]; exist {
-			if _, exist := queries["value"]; exist {
-				if v, err := strconv.ParseFloat(queries.Get("value"), 64); err != nil {
-					api.nodeScheduler.Knowledgebase.AddRawMeasure(queries.Get("key"), queries.Get("value"))
-				} else {
-					api.nodeScheduler.Knowledgebase.AddRawMeasure(queries.Get("key"), v)
-				}
-				response := datatype.NewAPIMessageBuilder().AddEntity("status", "success").Build()
-				respondJSON(w, http.StatusOK, response.ToJson())
-			} else {
-				response := datatype.NewAPIMessageBuilder().AddError("no value= found").Build()
-				respondJSON(w, http.StatusOK, response.ToJson())
-			}
-		} else {
-			response := datatype.NewAPIMessageBuilder().AddError("no key= found").Build()
-			respondJSON(w, http.StatusOK, response.ToJson())
-		}
-	case http.MethodPost:
-		r.ParseForm()
-		subject := r.Form.Get("subject")
-		value := r.Form.Get("value")
-		log.Printf("%s %s", subject, value)
-		// Memorize(subject, value)
-		// api.nodeScheduler.Knowledgebase.
-		respondJSON(w, http.StatusOK, subject+value)
-	case http.MethodDelete:
-		log.Print("hit DELETE")
-		r.ParseForm()
-		subject := r.Form.Get("subject")
-		respondJSON(w, http.StatusOK, subject)
-	}
+	w.Write(data)
 }
 
 func (api *APIServer) handlerGoals(w http.ResponseWriter, r *http.Request) {
@@ -130,6 +72,43 @@ func (api *APIServer) handlerGoals(w http.ResponseWriter, r *http.Request) {
 			api.nodeScheduler.GoalManager.AddGoal(&goal)
 		}
 		response := datatype.NewAPIMessageBuilder().AddEntity("status", "success").Build()
+		respondJSON(w, http.StatusOK, response.ToJson())
+	}
+}
+
+func (api *APIServer) handlerSchedule(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		// clauses := PrintClauses()
+		// respondJSON(w, http.StatusOK, clauses)
+	case http.MethodPost:
+		var newPlugin datatype.Plugin
+		defer r.Body.Close()
+		blob, err := io.ReadAll(r.Body)
+		if err != nil {
+			response := datatype.NewAPIMessageBuilder().AddError(err.Error()).Build()
+			respondJSON(w, http.StatusBadRequest, response.ToJson())
+			return
+		} else {
+			logger.Debug.Printf("%s", string(blob))
+			err = json.Unmarshal(blob, &newPlugin)
+			if err != nil {
+				response := datatype.NewAPIMessageBuilder().AddError(err.Error()).Build()
+				respondJSON(w, http.StatusBadRequest, response.ToJson())
+				return
+			}
+		}
+		logger.Info.Printf("locally requested to add plugin %q to schedule", newPlugin.Name)
+		e := datatype.NewEventBuilder(datatype.EventPluginStatusPromoted).AddReason("locally scheduled").Build()
+		// api.nodeScheduler.LogToBeehive.SendWaggleMessageOnNodeAsync(response.ToWaggleMessage(), "node")
+		pr := datatype.NewPluginRuntimeWithScienceRule(newPlugin, datatype.ScienceRule{})
+		pr.EnablePluginController = true
+		api.nodeScheduler.readyQueue.Push(pr)
+		api.nodeScheduler.chanNeedScheduling <- e
+
+		response := datatype.NewAPIMessageBuilder().
+			AddEntity("plugin_name", pr.Plugin.Name).
+			AddEntity("status", "success").Build()
 		respondJSON(w, http.StatusOK, response.ToJson())
 	}
 }

--- a/pkg/pluginctl/pluginctl.go
+++ b/pkg/pluginctl/pluginctl.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
-	"github.com/influxdata/influxdb-client-go/v2/domain"
 	"github.com/waggle-sensor/edge-scheduler/pkg/datatype"
 	"github.com/waggle-sensor/edge-scheduler/pkg/logger"
 	"github.com/waggle-sensor/edge-scheduler/pkg/nodescheduler"
@@ -469,7 +468,7 @@ func (p *PluginCtl) GetPerformanceData(s time.Time, e time.Time, pluginName stri
 	queryAPI := p.MetricsServer.Client.QueryAPI("waggle")
 	f, err := os.OpenFile(fmt.Sprintf("%s.csv", pluginName), os.O_CREATE|os.O_WRONLY, 0644)
 	defer f.Close()
-	result, err := queryAPI.QueryRaw(context.Background(), q, &domain.Dialect{})
+	result, err := queryAPI.QueryRaw(context.Background(), q, influxdb2.DefaultDialect())
 	if err == nil {
 		n, err := f.WriteString(result)
 		if err != nil {

--- a/pkg/pluginctl/pluginctl.go
+++ b/pkg/pluginctl/pluginctl.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -102,7 +101,7 @@ func (p *PluginCtl) ConnectToMetricsServer(config MetricsServerConfig) error {
 	} else {
 		path = config.InfluxDBTokenPath
 	}
-	tokenBlob, err := ioutil.ReadFile(path)
+	tokenBlob, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("Failed to read token at %s: %s", config.InfluxDBTokenPath, err)
 	}

--- a/pkg/pluginctl/pluginctl.go
+++ b/pkg/pluginctl/pluginctl.go
@@ -348,7 +348,10 @@ func (p *PluginCtl) RunAsync(dep *Deployment, chEvent chan<- datatype.Event, out
 }
 
 func (p *PluginCtl) PrintLog(pluginName string, follow bool) (func(), chan os.Signal, error) {
-	podLog, err := p.ResourceManager.GetPodLogHandler(pluginName, follow)
+	podLog, err := p.ResourceManager.GetPodLogHandler(pluginName, &apiv1.PodLogOptions{
+		Container: pluginName,
+		Follow:    follow,
+	})
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
- Node scheduler crashes when plugin's Kubernetes watcher receives an event without the information regarding Pod/Containers state. Now, it handles those errors and safely cleans them up
- `pluginctl profile get` added `--since -10h` to query profile information with an explicit time window