### PR TITLE
env supports value from Secret

### DIFF
--- a/cmd/pluginctl/cmd/rm.go
+++ b/cmd/pluginctl/cmd/rm.go
@@ -17,7 +17,7 @@ var cmdRm = &cobra.Command{
 	Use:              "rm APP_NAME",
 	Short:            "Remove plugin",
 	TraverseChildren: true,
-	Args:             cobra.MaximumNArgs(1),
+	Args:             cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		logger.Debug.Printf("kubeconfig: %s", kubeconfig)
 		name := args[0]

--- a/cmd/runplugin/main.go
+++ b/cmd/runplugin/main.go
@@ -66,7 +66,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	resourceManager, err := nodescheduler.NewK3SResourceManager(false, kubeconfig, "runplugin", false)
+	resourceManager, err := nodescheduler.NewK3SResourceManager(false, kubeconfig, "runplugin")
 	if err != nil {
 		log.Fatalf("nodescheduler.NewK3SResourceManager: %s", err.Error())
 	}
@@ -164,7 +164,7 @@ func runPlugin(resourceManager *nodescheduler.ResourceManager, plugin *datatype.
 	return nil
 }
 
-func updateDeployment(clientset *kubernetes.Clientset, deployment *v1.Deployment) error {
+func updateDeployment(clientset kubernetes.Interface, deployment *v1.Deployment) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 

--- a/data/jobs/a_policy_example.yaml
+++ b/data/jobs/a_policy_example.yaml
@@ -4,22 +4,21 @@ plugins:
 - name: myfirstapp
   pluginSpec:
     image: registry.sagecontinuum.org/theone/imagesampler:0.3.0
-    entrypoint: /bin/bash
+    entrypoint: bash
     args:
     - -c
-    - "echo hello world; sleep 10; echo bye"
+    - "echo hello world; sleep 60; echo bye"
 - name: mysecondapp
   pluginSpec:
     image: registry.sagecontinuum.org/theone/imagesampler:0.3.0
-    entrypoint: /bin/bash
+    entrypoint: bash
     args:
     - -c
-    - "echo hello world; sleep 5; echo bye"
+    - "echo hello world; sleep 30; echo bye"
 nodes:
-  W097:
+  W023:
 scienceRules:
-- "schedule(myfirstapp): True"
-- "schedule(mysecondapp): True"
-#- "myfirstapp: cronjob('myfirstapp', '0 * * * *')"
+- "schedule(myfirstapp): cronjob('myfirstapp', '*/10 * * * *')"
+- "schedule(mysecondapp): cronjob('mysecondapp', '*/10 * * * *')"
 successcriteria:
 - WallClock(1d)

--- a/data/jobs/secret_env.yaml
+++ b/data/jobs/secret_env.yaml
@@ -1,0 +1,19 @@
+---
+name: secret-in-env
+plugins:
+- name: app-printenv
+  pluginSpec:
+    image: registry.sagecontinuum.org/theone/imagesampler:0.3.0
+    entrypoint: bash
+    args:
+    - -c
+    - "printenv; sleep 60; echo bye"
+    env:
+      MYENV_A: "{secret.mysecret.a}"
+      MYENV_B: "{secret.mysecret.b}"
+nodes:
+  N002:
+scienceRules:
+- "schedule(app-printenv): cronjob('app-printenv', '*/5 * * * *')"
+successcriteria:
+- WallClock(1d)

--- a/pkg/nodescheduler/resourcemanager_test.go
+++ b/pkg/nodescheduler/resourcemanager_test.go
@@ -1,0 +1,38 @@
+package nodescheduler
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+)
+
+func TestEnvFromSecret(t *testing.T) {
+	pluginEnvFromSecretRegexFormat = regexp.MustCompile(`^{secret\.([a-z0-9-]+).([a-zA-Z0-9]+)}$`)
+
+	kv := map[string]string{
+		"ENV1":                    "123",
+		"{secret.mysecret.myenv}": "helloworld",
+	}
+	expected := map[string]string{
+		"ENV1":  "123",
+		"myenv": "helloworld",
+	}
+	parsed := make(map[string]string)
+	for k, v := range kv {
+		// if the environment variable name refers to a Kubernetes Secret,
+		// then we check and load the Secret from Kubernetes.
+		// Else, the it may be just a variable name
+		// FYI, len(sp) must be 3; [{secret.mysecret.myenv} mysecret myenv]
+		if sp := pluginEnvFromSecretRegexFormat.FindStringSubmatch(k); len(sp) == 3 {
+			// secretName := sp[1]
+			keyName := sp[2]
+			// fmt.Printf("%v and name is %q, env name is %q", sp, secretName, keyName)
+			parsed[keyName] = v
+		} else {
+			parsed[k] = v
+		}
+	}
+	if !reflect.DeepEqual(parsed, expected) {
+		t.Errorf("%+v but expected %+v", parsed, expected)
+	}
+}

--- a/pkg/pluginctl/pluginctl.go
+++ b/pkg/pluginctl/pluginctl.go
@@ -58,7 +58,7 @@ type Deployment struct {
 }
 
 func NewPluginCtl(kubeconfig string) (*PluginCtl, error) {
-	resourceManager, err := nodescheduler.NewK3SResourceManager(false, kubeconfig, "pluginctl", false)
+	resourceManager, err := nodescheduler.NewK3SResourceManager(false, kubeconfig, "pluginctl")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This simple change includes the functionality that allows users to specify env values from Kubernetes Secret, with the assumption that the Secret already exists inside the node. The format is,

```yaml
plugins:
- name: myplugin
  image: ...
  env:
    MYENV: {secret.mysecret.mykey}
```

The scheduler reads `mykey` from Kubernetes Secret named `mysecret` and loads the value of it to set the environmental variable `MYENV`. Pluginctl can do the same,

```bash
pluginctl run --name test \
  --entrypoint bash \
  --env MYENV={secret.mysecret.mykey} \
  waggle/plugin-base:1.1.1-base -- \
  -c 'printenv | grep MYENV'
```
If such Secret does not exist or the Secret does not have the key, then pluginctl will raise an exception,

```bash
Error: Secret mysecret does not have the variable a. Please check.
Secret mysecret does not have the variable a. Please check.
```

In the job description, this error message may appear in the job UI in the portal.