### PR TITLE
Illegal plugin state transitions

### DIFF
--- a/cmd/pluginctl/cmd/deploy.go
+++ b/cmd/pluginctl/cmd/deploy.go
@@ -23,6 +23,8 @@ func init() {
 	flags.BoolVar(&deployment.DevelopMode, "develop", false, "Enable the following development time features: access to wan network")
 	flags.StringVar(&deployment.Type, "type", "pod", "Type of the plugin. It is one of ['pod', 'job', 'deployment', 'daemonset]. Default is 'pod'.")
 	flags.StringVar(&deployment.ResourceString, "resource", "", "Specify resource requirement for running the plugin as a comma-separated list without spaces. For example, resource.cpu=1,limit.cpu=2.")
+	// The volume feature is disabled as this holds a security problem
+	// flags.StringSliceVarP(&deployment.Volume, "volume", "v", []string{}, "Host path to mount the volume into the plugin")
 	flags.BoolVar(&deployment.EnablePluginController, "enable-plugin-controller", false, "Enable plugin controller supporting the plugin")
 	flags.BoolVar(&deployment.ForceToUpdate, "force-to-update", false, "Force to create the plugin when failed to update it")
 	rootCmd.AddCommand(cmdDeploy)

--- a/cmd/pluginctl/cmd/run.go
+++ b/cmd/pluginctl/cmd/run.go
@@ -26,6 +26,8 @@ func init() {
 	flags.StringVarP(&deployment.EnvFromFile, "env-from", "", "", "Set environment variables from file")
 	flags.BoolVar(&deployment.DevelopMode, "develop", false, "Enable the following development time features: access to wan network")
 	flags.StringVar(&deployment.ResourceString, "resource", "", "Specify resource requirement for running the plugin as a comma-separated list without spaces. For example, resource.cpu=1,limit.cpu=2.")
+	// The volume feature is disabled as this holds a security problem
+	// flags.StringSliceVarP(&deployment.Volume, "volume", "v", []string{}, "Host path to mount the volume into the plugin")
 	rootCmd.AddCommand(cmdRun)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lithammer/dedent v1.1.0 // indirect
+	github.com/looplab/fsm v1.0.2 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -349,6 +349,8 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffktY=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
+github.com/looplab/fsm v1.0.2 h1:f0kdMzr4CRpXtaKKRUxwLYJ7PirTdwrtNumeLN+mDx8=
+github.com/looplab/fsm v1.0.2/go.mod h1:PmD3fFvQEIsjMEfvZdrCDZ6y8VwKTwWNjlpEr6IKPO4=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/pkg/datatype/plugin.go
+++ b/pkg/datatype/plugin.go
@@ -41,6 +41,7 @@ type PluginSpec struct {
 	Env         map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
 	DevelopMode bool              `json:"develop,omitempty" yaml:"develop,omitempty"`
 	Resource    map[string]string `json:"resource,omitempty" yaml:"resource,omitempty"`
+	Volume      map[string]string `json:"volume,omitempty" yaml:"volume,omitempty`
 }
 
 func (ps *PluginSpec) GetImageTag() (string, error) {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -10,6 +10,8 @@ var (
 	Debug = log.New(os.Stdout, "DEBUG: ", log.Ldate|log.Ltime|log.Lshortfile)
 	// Info logs information helpful to know
 	Info = log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile)
+	// Warn logs warnings
+	Warn = log.New(os.Stdout, "WARNING: ", log.Ldate|log.Ltime|log.Lshortfile)
 	// Error logs errors
 	Error = log.New(os.Stdout, "ERROR: ", log.Ldate|log.Ltime|log.Lshortfile)
 )

--- a/pkg/nodescheduler/nodegoalmanager.go
+++ b/pkg/nodescheduler/nodegoalmanager.go
@@ -118,7 +118,7 @@ func (ngm *NodeGoalManager) GetPluginRuntimeByPodUID(uid string) *datatype.Plugi
 
 func (ngm *NodeGoalManager) GetQueuedPluginRuntime() (r []*datatype.PluginRuntime) {
 	for _, pr := range ngm.LoadedPlugins {
-		if pr.Status.State == datatype.Queued {
+		if pr.Status.Is(string(datatype.Queued)) {
 			r = append(r, pr)
 		}
 	}

--- a/pkg/nodescheduler/nodescheduler.go
+++ b/pkg/nodescheduler/nodescheduler.go
@@ -310,7 +310,7 @@ func (ns *NodeScheduler) handleKubernetesPodEvent(e KubernetesEvent) {
 	case KubernetesEventTypeAdd:
 		logger.Info.Printf("Plugin %q is scheduled", pod.Name)
 		if err := pr.Scheduled(); err != nil {
-			logger.Error.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Queued, err.Error())
+			logger.Error.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Scheduled, err.Error())
 		} else {
 			pr.SetPodUID(string(pod.UID))
 			msg := datatype.NewSchedulerEventBuilder(datatype.EventPluginStatusScheduled).
@@ -334,9 +334,9 @@ func (ns *NodeScheduler) handleKubernetesPodEvent(e KubernetesEvent) {
 			// we expect init container running and completion
 			if err := pr.Initializing(); err != nil {
 				if errors.Is(err, fsm.NoTransitionError{}) {
-					logger.Debug.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Queued, err.Error())
+					logger.Debug.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Initializing, err.Error())
 				} else {
-					logger.Error.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Queued, err.Error())
+					logger.Error.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Initializing, err.Error())
 				}
 			} else {
 				logger.Info.Printf("plugin %q is being initialized", pod.Name)
@@ -356,9 +356,9 @@ func (ns *NodeScheduler) handleKubernetesPodEvent(e KubernetesEvent) {
 				logger.Error.Println(e)
 				if err := pr.Failed(); err != nil {
 					if errors.Is(err, fsm.NoTransitionError{}) {
-						logger.Debug.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Queued, err.Error())
+						logger.Debug.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Failed, err.Error())
 					} else {
-						logger.Error.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Queued, err.Error())
+						logger.Error.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Failed, err.Error())
 					}
 				} else {
 					messageBuilder, err := ns.ResourceManager.AnalyzeFailureOfPod(pod)
@@ -398,9 +398,9 @@ func (ns *NodeScheduler) handleKubernetesPodEvent(e KubernetesEvent) {
 				logger.Info.Printf("Plugin %q starts to run", pod.Name)
 				if err := pr.Running(); err != nil {
 					if errors.Is(err, fsm.NoTransitionError{}) {
-						logger.Warn.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Queued, err.Error())
+						logger.Warn.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Running, err.Error())
 					} else {
-						logger.Error.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Queued, err.Error())
+						logger.Error.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Running, err.Error())
 					}
 				} else {
 					msg := datatype.NewSchedulerEventBuilder(datatype.EventPluginStatusRunning).
@@ -417,9 +417,9 @@ func (ns *NodeScheduler) handleKubernetesPodEvent(e KubernetesEvent) {
 			//       trigger message multiple times.
 			if err := pr.Completed(); err != nil {
 				if errors.Is(err, fsm.NoTransitionError{}) {
-					logger.Warn.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Queued, err.Error())
+					logger.Warn.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Completed, err.Error())
 				} else {
-					logger.Error.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Queued, err.Error())
+					logger.Error.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Completed, err.Error())
 				}
 			} else {
 				logger.Info.Printf("Plugin %q succeeded", pod.Name)
@@ -453,9 +453,9 @@ func (ns *NodeScheduler) handleKubernetesPodEvent(e KubernetesEvent) {
 			//       Thus, we ignore duplicated events.
 			if err := pr.Failed(); err != nil {
 				if errors.Is(err, fsm.NoTransitionError{}) {
-					logger.Warn.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Queued, err.Error())
+					logger.Warn.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Failed, err.Error())
 				} else {
-					logger.Error.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Queued, err.Error())
+					logger.Error.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Failed, err.Error())
 				}
 			} else {
 				logger.Info.Printf("Plugin %q failed", pod.Name)
@@ -497,9 +497,9 @@ func (ns *NodeScheduler) handleKubernetesPodEvent(e KubernetesEvent) {
 			// We mark this as a failure.
 			if err := pr.Failed(); err != nil {
 				if errors.Is(err, fsm.NoTransitionError{}) {
-					logger.Warn.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Queued, err.Error())
+					logger.Warn.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Failed, err.Error())
 				} else {
-					logger.Error.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Queued, err.Error())
+					logger.Error.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Failed, err.Error())
 				}
 			} else {
 				privateMessage = datatype.NewSchedulerEventBuilder(datatype.EventPluginStatusFailed).
@@ -519,9 +519,9 @@ func (ns *NodeScheduler) handleKubernetesPodEvent(e KubernetesEvent) {
 		ns.scheduledPlugins.Pop(pr)
 		if err := pr.Inactive(); err != nil {
 			if errors.Is(err, fsm.NoTransitionError{}) {
-				logger.Warn.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Queued, err.Error())
+				logger.Warn.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Inactive, err.Error())
 			} else {
-				logger.Error.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Queued, err.Error())
+				logger.Error.Printf("plugin %q failed to transition from %s to %s: %s", pr.Plugin.Name, pr.Status.Current(), datatype.Inactive, err.Error())
 			}
 		} else {
 			ns.chanNeedScheduling <- privateMessage

--- a/pkg/pluginctl/selector_parser.go
+++ b/pkg/pluginctl/selector_parser.go
@@ -14,7 +14,7 @@ func ParseSelector(s string) (map[string]string, error) {
 	}
 
 	for _, term := range strings.Split(s, ",") {
-		k, v, err := parseSelectorTerm(term)
+		k, v, err := parseTerm(term, "=")
 		if err != nil {
 			return items, err
 		}
@@ -24,10 +24,10 @@ func ParseSelector(s string) (map[string]string, error) {
 	return items, nil
 }
 
-func parseSelectorTerm(s string) (string, string, error) {
-	fields := strings.Split(s, "=")
+func parseTerm(s string, delimiter string) (string, string, error) {
+	fields := strings.Split(s, delimiter)
 	if len(fields) != 2 {
-		return "", "", fmt.Errorf("selector terms must have exactly one =")
+		return "", "", fmt.Errorf("terms must have exactly one %s", delimiter)
 	}
 	return strings.TrimSpace(fields[0]), strings.TrimSpace(fields[1]), nil
 }


### PR DESCRIPTION
When there is an error in running plugins, the scheduler attempts invalid transitions on the plugin state. This transition occurs because it blindly processes Kubernetes events without monitoring the transitions. For example (See the logs below), the plugin was removed because of the error "FailedMount." However, Kubernetes keeps sending those Kubernetes Events with the same error and the scheduler changed the plugin state from "inactive" (after the plugin removal) to "failed" because of the events. Then, the plugin state stays in "failed" because there will not be further Kubernetes PodFailed Events that trigger the plugin state to "inactive." Note that the plugin state has to come to "inactive" in order for it to be scheduled by its science rules.

```bash
INFO: 2024/10/03 13:55:08 nodescheduler.go:245: Plugin "object-counter-bottom-26" is created
INFO: 2024/10/03 13:55:09 nodescheduler.go:308: Plugin "object-counter-bottom-26" is scheduled
INFO: 2024/10/03 13:55:09 nodescheduler.go:330: plugin "object-counter-bottom-26" is being initialized
INFO: 2024/10/03 13:55:10 nodescheduler.go:510: Plugin "object-counter-bottom-26" failed due to FailedMount
INFO: 2024/10/03 13:55:10 nodescheduler.go:330: plugin "object-counter-bottom-26" is being initialized
INFO: 2024/10/03 13:55:10 nodescheduler.go:445: Plugin "object-counter-bottom-26" removed
INFO: 2024/10/03 13:55:11 nodescheduler.go:510: Plugin "object-counter-bottom-26" failed due to FailedMount
INFO: 2024/10/03 13:55:13 nodescheduler.go:510: Plugin "object-counter-bottom-26" failed due to FailedMount
INFO: 2024/10/03 13:55:16 nodescheduler.go:510: Plugin "object-counter-bottom-26" failed due to FailedMount
INFO: 2024/10/03 13:55:21 nodescheduler.go:510: Plugin "object-counter-bottom-26" failed due to FailedMount
INFO: 2024/10/03 13:55:30 nodescheduler.go:510: Plugin "object-counter-bottom-26" failed due to FailedMount
INFO: 2024/10/03 13:55:48 nodescheduler.go:510: Plugin "object-counter-bottom-26" failed due to FailedMount
INFO: 2024/10/03 13:56:21 nodescheduler.go:510: Plugin "object-counter-bottom-26" failed due to FailedMount
INFO: 2024/10/03 13:57:12 nodescheduler.go:510: Plugin "object-counter-bottom-26" failed due to FailedMount
INFO: 2024/10/03 14:57:21 nodescheduler.go:510: Plugin "object-counter-bottom-26" failed due to FailedMount
INFO: 2024/10/03 14:58:12 nodescheduler.go:510: Plugin "object-counter-bottom-26" failed due to FailedMount
```

To resolve this problem, the scheduler should reject illegal state transitions.