### PR TITLE
Added a garbage collector for dangling Pods

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM waggle/plugin-base:1.1.1-base as base
 RUN apt-get update \
   && apt-get install -y \
   build-essential \
-  gcc-multilib \
+  # gcc-multilib \
   pkg-config \
   # build-base \
   wget \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM waggle/plugin-base:1.1.1-base as base
 RUN apt-get update \
   && apt-get install -y \
   build-essential \
+  gcc-multilib \
   pkg-config \
   # build-base \
   wget \

--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,12 @@ cli:
 scheduler-all-arch: scheduler-amd64 scheduler-arm64
 
 scheduler-amd64:
-	GOOS=linux GOARCH=amd64 go build -o ./out/cloudscheduler-amd64 -ldflags "-X main.Version=${VERSION}" cmd/cloudscheduler/main.go
-	GOOS=linux GOARCH=amd64 go build -o ./out/nodescheduler-amd64 -ldflags "-X main.Version=${VERSION}" cmd/nodescheduler/main.go
+	CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -o ./out/cloudscheduler-amd64 -ldflags "-X main.Version=${VERSION}" cmd/cloudscheduler/main.go
+	CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -o ./out/nodescheduler-amd64 -ldflags "-X main.Version=${VERSION}" cmd/nodescheduler/main.go
 
 scheduler-arm64:
-	GOOS=linux GOARCH=arm64 go build -o ./out/cloudscheduler-arm64 -ldflags "-X main.Version=${VERSION}" cmd/cloudscheduler/main.go
-	GOOS=linux GOARCH=arm64 go build -o ./out/nodescheduler-arm64 -ldflags "-X main.Version=${VERSION}" cmd/nodescheduler/main.go
+	CGO_ENABLED=1 GOOS=linux GOARCH=arm64 go build -o ./out/cloudscheduler-arm64 -ldflags "-X main.Version=${VERSION}" cmd/cloudscheduler/main.go
+	CGO_ENABLED=1 GOOS=linux GOARCH=arm64 go build -o ./out/nodescheduler-arm64 -ldflags "-X main.Version=${VERSION}" cmd/nodescheduler/main.go
 
 scheduler:
 	go build -o ./out/cloudscheduler -ldflags "-X main.Version=${VERSION}" ./cmd/cloudscheduler

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-https://github.com/waggle-sensor/pywaggle/archive/0.43.2.zip
+pywaggle==0.56.*


### PR DESCRIPTION
This pull request includes several changes to the `pkg/nodescheduler/resourcemanager.go` file, focusing on enabling the garbage collection process using the time-to-live (TTL) settings for completed or failed pods.

* TTL settings: Set `ttlSecondsAfterFinished` to 60 seconds to reduce the time completed or failed pods remain before being cleaned up.

* Improvements to garbage collection: Added a ticker to periodically run the `RunGabageCollector` function every minute, ensuring regular cleanup of dangling pods.