### PR TITLE
feat: Added --volume parameter for volume mounting

### DIFF
--- a/cmd/pluginctl/cmd/deploy.go
+++ b/cmd/pluginctl/cmd/deploy.go
@@ -23,8 +23,8 @@ func init() {
 	flags.BoolVar(&deployment.DevelopMode, "develop", false, "Enable the following development time features: access to wan network")
 	flags.StringVar(&deployment.Type, "type", "pod", "Type of the plugin. It is one of ['pod', 'job', 'deployment', 'daemonset]. Default is 'pod'.")
 	flags.StringVar(&deployment.ResourceString, "resource", "", "Specify resource requirement for running the plugin as a comma-separated list without spaces. For example, resource.cpu=1,limit.cpu=2.")
-	// The volume feature is disabled as this holds a security problem
-	// flags.StringSliceVarP(&deployment.Volume, "volume", "v", []string{}, "Host path to mount the volume into the plugin")
+	// NOTE: Volume may hold a security problem
+	flags.StringSliceVarP(&deployment.Volume, "volume", "v", []string{}, "Host path to mount the volume into the plugin")
 	flags.BoolVar(&deployment.EnablePluginController, "enable-plugin-controller", false, "Enable plugin controller supporting the plugin")
 	flags.BoolVar(&deployment.ForceToUpdate, "force-to-update", false, "Force to create the plugin when failed to update it")
 	rootCmd.AddCommand(cmdDeploy)

--- a/cmd/pluginctl/cmd/run.go
+++ b/cmd/pluginctl/cmd/run.go
@@ -26,8 +26,8 @@ func init() {
 	flags.StringVarP(&deployment.EnvFromFile, "env-from", "", "", "Set environment variables from file")
 	flags.BoolVar(&deployment.DevelopMode, "develop", false, "Enable the following development time features: access to wan network")
 	flags.StringVar(&deployment.ResourceString, "resource", "", "Specify resource requirement for running the plugin as a comma-separated list without spaces. For example, resource.cpu=1,limit.cpu=2.")
-	// The volume feature is disabled as this holds a security problem
-	// flags.StringSliceVarP(&deployment.Volume, "volume", "v", []string{}, "Host path to mount the volume into the plugin")
+	// NOTE: Volume may hold a security problem
+	flags.StringSliceVarP(&deployment.Volume, "volume", "v", []string{}, "Host path to mount the volume into the plugin")
 	rootCmd.AddCommand(cmdRun)
 }
 


### PR DESCRIPTION
This pull request reintroduces and modifies the volume mounting feature in the plugin system, which was previously disabled due to security concerns. The changes include updates to command-line flags, security checks, and logic for handling volumes in the resource manager.

### Reintroduction of Volume Mounting:

* `cmd/pluginctl/cmd/deploy.go` and `cmd/pluginctl/cmd/run.go`: Re-enabled the `--volume` flag for specifying host paths to mount into plugins. Added a note highlighting potential security risks associated with this feature. [[1]](diffhunk://#diff-7798296f16b351fd0dbe4aa2ed0de84f03f86ca05f197354deb4d67058bb1bffL26-R27) [[2]](diffhunk://#diff-0dac6919b26f17281d9ba06d4623b5a966270d3d4dceaa70b060ce83bccf468cL29-R30)

### Security Enhancements and Logic Updates:

* `pkg/nodescheduler/resourcemanager.go`:
  - Reintroduced logic for mounting volumes in `createPodTemplateSpecForPlugin`, with updated comments and safeguards. Added a check to ensure that root-owned volumes should not be mounted, though the implementation is currently incomplete and marked as a TODO.
  - Introduced a requirement for specifying a `nodeSelector` when volumes are mounted, to ensure the Kubernetes scheduler places the pod on the correct node.
  - Updated the `NodeSelector` field in the pod spec to use the new `nodeSelector` variable.