### PR TITLE
Added volume mounting for plugins.

### DIFF
--- a/cmd/pluginctl/cmd/deploy.go
+++ b/cmd/pluginctl/cmd/deploy.go
@@ -23,8 +23,8 @@ func init() {
 	flags.BoolVar(&deployment.DevelopMode, "develop", false, "Enable the following development time features: access to wan network")
 	flags.StringVar(&deployment.Type, "type", "pod", "Type of the plugin. It is one of ['pod', 'job', 'deployment', 'daemonset]. Default is 'pod'.")
 	flags.StringVar(&deployment.ResourceString, "resource", "", "Specify resource requirement for running the plugin as a comma-separated list without spaces. For example, resource.cpu=1,limit.cpu=2.")
-	// The volume feature is disabled as this holds a security problem
-	// flags.StringSliceVarP(&deployment.Volume, "volume", "v", []string{}, "Host path to mount the volume into the plugin")
+	// NOTE: Volume may hold a security problem
+	flags.StringSliceVarP(&deployment.Volume, "volume", "v", []string{}, "Host path to mount the volume into the plugin")
 	flags.BoolVar(&deployment.EnablePluginController, "enable-plugin-controller", false, "Enable plugin controller supporting the plugin")
 	flags.BoolVar(&deployment.ForceToUpdate, "force-to-update", false, "Force to create the plugin when failed to update it")
 	rootCmd.AddCommand(cmdDeploy)

--- a/cmd/pluginctl/cmd/run.go
+++ b/cmd/pluginctl/cmd/run.go
@@ -26,8 +26,8 @@ func init() {
 	flags.StringVarP(&deployment.EnvFromFile, "env-from", "", "", "Set environment variables from file")
 	flags.BoolVar(&deployment.DevelopMode, "develop", false, "Enable the following development time features: access to wan network")
 	flags.StringVar(&deployment.ResourceString, "resource", "", "Specify resource requirement for running the plugin as a comma-separated list without spaces. For example, resource.cpu=1,limit.cpu=2.")
-	// The volume feature is disabled as this holds a security problem
-	// flags.StringSliceVarP(&deployment.Volume, "volume", "v", []string{}, "Host path to mount the volume into the plugin")
+	// NOTE: Volume may hold a security problem
+	flags.StringSliceVarP(&deployment.Volume, "volume", "v", []string{}, "Host path to mount the volume into the plugin")
 	rootCmd.AddCommand(cmdRun)
 }
 

--- a/pkg/cloudscheduler/api_server.go
+++ b/pkg/cloudscheduler/api_server.go
@@ -615,7 +615,7 @@ func (api *APIServer) handlerGoalStreamForNode(w http.ResponseWriter, r *http.Re
 	if len(goals) < 1 {
 		event := datatype.NewSchedulerEventBuilder(datatype.EventGoalStatusUpdated).
 			AddEntry("goals", "[]").
-			Build().(datatype.SchedulerEvent)
+			Build()
 		if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event.ToString(), event.GetEntry("goals")); err != nil {
 			return
 		}
@@ -627,7 +627,7 @@ func (api *APIServer) handlerGoalStreamForNode(w http.ResponseWriter, r *http.Re
 		} else {
 			event := datatype.NewSchedulerEventBuilder(datatype.EventGoalStatusUpdated).
 				AddEntry("goals", string(blob)).
-				Build().(datatype.SchedulerEvent)
+				Build()
 			if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event.ToString(), event.GetEntry("goals")); err != nil {
 				return
 			}

--- a/pkg/cloudscheduler/cloudscheduler.go
+++ b/pkg/cloudscheduler/cloudscheduler.go
@@ -251,7 +251,7 @@ func (cs *CloudScheduler) updateNodes(nodes []string) {
 			logger.Error.Printf("Failed to compress goals for node %q before pushing", nodeName)
 		} else {
 			event := datatype.NewSchedulerEventBuilder(datatype.EventGoalStatusUpdated).AddEntry("goals", string(blob)).Build()
-			cs.APIServer.Push(nodeName, &event)
+			cs.APIServer.Push(nodeName, event)
 		}
 	}
 }

--- a/pkg/datatype/event.go
+++ b/pkg/datatype/event.go
@@ -103,7 +103,7 @@ func (s *SchedulerEventBuilder) AddPodMeta(pod *apiv1.Pod) *SchedulerEventBuilde
 	return s
 }
 
-func (s *SchedulerEventBuilder) Build() Event {
+func (s *SchedulerEventBuilder) Build() SchedulerEvent {
 	return s.e
 }
 

--- a/pkg/datatype/event_test.go
+++ b/pkg/datatype/event_test.go
@@ -30,10 +30,10 @@ func TestEventWaggleConversion(t *testing.T) {
 				e.AddEntry(k, v.(float64))
 			}
 		}
-		msg := e.Build().(SchedulerEvent)
+		msg := e.Build()
 		waggleMsg := msg.ToWaggleMessage()
 		unWaggleMsgBuilder, _ := NewSchedulerEventBuilderFromWaggleMessage(waggleMsg)
-		unWaggleMsg := unWaggleMsgBuilder.Build().(SchedulerEvent)
+		unWaggleMsg := unWaggleMsgBuilder.Build()
 		if unWaggleMsg.Type != EventType(test.Type) {
 			t.Errorf("Type mismatch: wanted %s, got %s", test.Type, unWaggleMsg.Type)
 		}

--- a/pkg/interfacing/rmq.go
+++ b/pkg/interfacing/rmq.go
@@ -233,7 +233,7 @@ func (rh *RabbitMQHandler) SubscribeEvents(exchange string, queueName string, to
 						eventBuilder.AddEntry("vsn", vsn)
 					}
 					event := eventBuilder.Build()
-					ch <- &event
+					ch <- event
 				}
 			}
 		}

--- a/pkg/nodescheduler/nodescheduler.go
+++ b/pkg/nodescheduler/nodescheduler.go
@@ -137,7 +137,7 @@ func (ns *NodeScheduler) Run() {
 									AddPluginRuntimeMeta(*pr).
 									AddPluginMeta(pr.Plugin).
 									AddReason(fmt.Sprintf("triggered by %s", r.Condition)).
-									Build().(datatype.SchedulerEvent)
+									Build()
 								ns.LogToBeehive.SendWaggleMessageOnNodeAsync(msg.ToWaggleMessage(), "all")
 								ns.readyQueue.Push(pr)
 								triggerScheduling = true
@@ -180,7 +180,7 @@ func (ns *NodeScheduler) Run() {
 			if triggerScheduling {
 				privateMessage := datatype.NewSchedulerEventBuilder(datatype.EventPluginStatusQueued).
 					AddReason("kb triggered").
-					Build().(datatype.SchedulerEvent)
+					Build()
 				ns.chanNeedScheduling <- privateMessage
 			}
 		case event := <-ns.chanNeedScheduling:
@@ -205,7 +205,7 @@ func (ns *NodeScheduler) Run() {
 						AddReason("Fit to resource").
 						AddPluginRuntimeMeta(*_pr).
 						AddPluginMeta(_pr.Plugin).
-						Build().(datatype.SchedulerEvent)
+						Build()
 					logger.Debug.Printf("%s: %q (%q)", pluginEvent.ToString(), pluginEvent.GetPluginName(), pluginEvent.GetReason())
 					ns.LogToBeehive.SendWaggleMessageOnNodeAsync(pluginEvent.ToWaggleMessage(), "all")
 					pr := ns.readyQueue.Pop(_pr)
@@ -220,7 +220,7 @@ func (ns *NodeScheduler) Run() {
 								AddPluginRuntimeMeta(*pr).
 								AddReason(err.Error()).
 								AddPluginMeta(pr.Plugin).
-								Build().(datatype.SchedulerEvent)
+								Build()
 							ns.LogToBeehive.SendWaggleMessageOnNodeAsync(msg.ToWaggleMessage(), "all")
 							return
 						}
@@ -236,7 +236,7 @@ func (ns *NodeScheduler) Run() {
 								AddPluginRuntimeMeta(*pr).
 								AddReason(err.Error()).
 								AddPluginMeta(pr.Plugin).
-								Build().(datatype.SchedulerEvent)
+								Build()
 							ns.LogToBeehive.SendWaggleMessageOnNodeAsync(msg.ToWaggleMessage(), "all")
 							if err = ns.ResourceManager.TerminatePod(pod.Name); err != nil {
 								logger.Error.Printf("Failed to delete %s: %s", pod.Name, err.Error())
@@ -317,7 +317,7 @@ func (ns *NodeScheduler) handleKubernetesPodEvent(e KubernetesEvent) {
 				AddPluginRuntimeMeta(*pr).
 				AddPodMeta(pod).
 				AddPluginMeta(pr.Plugin).
-				Build().(datatype.SchedulerEvent)
+				Build()
 			ns.LogToBeehive.SendWaggleMessageOnNodeAsync(msg.ToWaggleMessage(), "all")
 
 			// NOTE: To support backward compatibility, we also send the "launched" event
@@ -325,7 +325,7 @@ func (ns *NodeScheduler) handleKubernetesPodEvent(e KubernetesEvent) {
 				AddPluginRuntimeMeta(*pr).
 				AddPodMeta(pod).
 				AddPluginMeta(pr.Plugin).
-				Build().(datatype.SchedulerEvent)
+				Build()
 			ns.LogToBeehive.SendWaggleMessageOnNodeAsync(msg2.ToWaggleMessage(), "all")
 		}
 	case KubernetesEventTypeModified:
@@ -344,7 +344,7 @@ func (ns *NodeScheduler) handleKubernetesPodEvent(e KubernetesEvent) {
 					AddPluginRuntimeMeta(*pr).
 					AddPodMeta(pod).
 					AddPluginMeta(pr.Plugin).
-					Build().(datatype.SchedulerEvent)
+					Build()
 				ns.LogToBeehive.SendWaggleMessageOnNodeAsync(msg.ToWaggleMessage(), "all")
 			}
 		case v1.PodRunning:
@@ -369,7 +369,7 @@ func (ns *NodeScheduler) handleKubernetesPodEvent(e KubernetesEvent) {
 						AddPodMeta(pod).
 						AddPluginMeta(pr.Plugin).
 						AddReason(e).
-						Build().(datatype.SchedulerEvent)
+						Build()
 					ns.LogToBeehive.SendWaggleMessageOnNodeAsync(message.ToWaggleMessage(), "all")
 					defer ns.ResourceManager.TerminatePod(pod.Name)
 				}
@@ -407,7 +407,7 @@ func (ns *NodeScheduler) handleKubernetesPodEvent(e KubernetesEvent) {
 						AddPluginRuntimeMeta(*pr).
 						AddPodMeta(pod).
 						AddPluginMeta(pr.Plugin).
-						Build().(datatype.SchedulerEvent)
+						Build()
 					ns.LogToBeehive.SendWaggleMessageOnNodeAsync(msg.ToWaggleMessage(), "all")
 				}
 			}
@@ -440,7 +440,7 @@ func (ns *NodeScheduler) handleKubernetesPodEvent(e KubernetesEvent) {
 					AddPluginRuntimeMeta(*pr).
 					AddPodMeta(pod).
 					AddPluginMeta(pr.Plugin).
-					Build().(datatype.SchedulerEvent)
+					Build()
 				ns.LogToBeehive.SendWaggleMessageOnNodeAsync(message2.ToWaggleMessage(), "all")
 				defer ns.ResourceManager.TerminatePod(pod.Name)
 			}
@@ -465,7 +465,7 @@ func (ns *NodeScheduler) handleKubernetesPodEvent(e KubernetesEvent) {
 				}
 				message := messageBuilder.AddPluginRuntimeMeta(*pr).
 					AddPluginMeta(pr.Plugin).
-					Build().(datatype.SchedulerEvent)
+					Build()
 				ns.LogToBeehive.SendWaggleMessageOnNodeAsync(message.ToWaggleMessage(), "all")
 				defer ns.ResourceManager.TerminatePod(pod.Name)
 			}
@@ -485,12 +485,12 @@ func (ns *NodeScheduler) handleKubernetesPodEvent(e KubernetesEvent) {
 			// We do nothing on this transition
 			privateMessage = datatype.NewSchedulerEventBuilder(datatype.EventPluginStatusComplete).
 				AddReason(fmt.Sprintf("plugin %q successfully removed", pod.Name)).
-				Build().(datatype.SchedulerEvent)
+				Build()
 		case string(datatype.Failed):
 			// The pod failed and should have been already reported. we do nothing
 			privateMessage = datatype.NewSchedulerEventBuilder(datatype.EventPluginStatusFailed).
 				AddReason(fmt.Sprintf("plugin %q removed due to a failure", pod.Name)).
-				Build().(datatype.SchedulerEvent)
+				Build()
 		default:
 			// The pod was deleted for unknown reason. One of the reasons might be
 			// that the Pod was deleted from external, e.g. kubectl delete pod.
@@ -504,14 +504,14 @@ func (ns *NodeScheduler) handleKubernetesPodEvent(e KubernetesEvent) {
 			} else {
 				privateMessage = datatype.NewSchedulerEventBuilder(datatype.EventPluginStatusFailed).
 					AddReason(fmt.Sprintf("plugin %q deleted from external", pod.Name)).
-					Build().(datatype.SchedulerEvent)
+					Build()
 
 				message := datatype.NewSchedulerEventBuilder(datatype.EventPluginStatusFailed).
 					AddReason("plugin deleted from external").
 					AddPluginRuntimeMeta(*pr).
 					AddPluginMeta(pr.Plugin).
 					AddPodMeta(pod).
-					Build().(datatype.SchedulerEvent)
+					Build()
 				ns.LogToBeehive.SendWaggleMessageOnNodeAsync(message.ToWaggleMessage(), "all")
 			}
 		}
@@ -563,7 +563,7 @@ func (ns *NodeScheduler) handleKubernetesEventEvent(e KubernetesEvent) {
 					AddPluginMeta(pr.Plugin).
 					AddReason(event.Reason).
 					AddEntry("message", event.Message).
-					Build().(datatype.SchedulerEvent)
+					Build()
 				ns.LogToBeehive.SendWaggleMessageOnNodeAsync(message.ToWaggleMessage(), "all")
 				defer ns.ResourceManager.TerminatePod(obj.Name)
 			default:
@@ -573,7 +573,7 @@ func (ns *NodeScheduler) handleKubernetesEventEvent(e KubernetesEvent) {
 				AddPluginMeta(pr.Plugin).
 				AddReason(event.Reason).
 				AddEntry("message", event.Message).
-				Build().(datatype.SchedulerEvent)
+				Build()
 			ns.LogToBeehive.SendWaggleMessageOnNodeAsync(message.ToWaggleMessage(), "all")
 		}
 	default:
@@ -661,7 +661,7 @@ func (ns *NodeScheduler) cleanUpGoal(goal *datatype.ScienceGoal) {
 							AddPluginMeta(a.Plugin).
 							AddPodMeta(pod).
 							AddReason("Cleaning up the plugin due to deletion of the goal").
-							Build().(datatype.SchedulerEvent)
+							Build()
 						ns.LogToBeehive.SendWaggleMessageOnNodeAsync(e.ToWaggleMessage(), "all")
 						ns.ResourceManager.TerminatePod(podName)
 						logger.Info.Printf("plugin %s is removed from running", p.Name)
@@ -702,7 +702,7 @@ func (ns *NodeScheduler) handleBulkGoals(goals []datatype.ScienceGoal) {
 				ns.registerGoal(&goal)
 				e := datatype.NewSchedulerEventBuilder(datatype.EventGoalStatusUpdated).
 					AddGoal(&goal).
-					Build().(datatype.SchedulerEvent)
+					Build()
 				ns.LogToBeehive.SendWaggleMessageOnNodeAsync(e.ToWaggleMessage(), "all")
 			}
 		} else {
@@ -710,7 +710,7 @@ func (ns *NodeScheduler) handleBulkGoals(goals []datatype.ScienceGoal) {
 			ns.registerGoal(&goal)
 			e := datatype.NewSchedulerEventBuilder(datatype.EventGoalStatusReceived).
 				AddGoal(&goal).
-				Build().(datatype.SchedulerEvent)
+				Build()
 			ns.LogToBeehive.SendWaggleMessageOnNodeAsync(e.ToWaggleMessage(), "all")
 		}
 	}
@@ -720,7 +720,7 @@ func (ns *NodeScheduler) handleBulkGoals(goals []datatype.ScienceGoal) {
 			ns.cleanUpGoal(&goal)
 			event := datatype.NewSchedulerEventBuilder(datatype.EventGoalStatusRemoved).
 				AddGoal(&goal).
-				Build().(datatype.SchedulerEvent)
+				Build()
 			ns.LogToBeehive.SendWaggleMessageOnNodeAsync(event.ToWaggleMessage(), "all")
 		}
 	}


### PR DESCRIPTION
This pull request re-enables and updates the volume mounting feature for plugins, addressing some security concerns while introducing additional checks and safeguards. The changes span across deployment, runtime commands, and the resource manager.

### Re-enabling Volume Mounting for Plugins:

* `cmd/pluginctl/cmd/deploy.go` and `cmd/pluginctl/cmd/run.go`: Re-enabled the `--volume` flag for specifying host paths to mount volumes into plugins. Updated comments to highlight potential security concerns. [[1]](diffhunk://#diff-7798296f16b351fd0dbe4aa2ed0de84f03f86ca05f197354deb4d67058bb1bffL26-R27) [[2]](diffhunk://#diff-0dac6919b26f17281d9ba06d4623b5a966270d3d4dceaa70b060ce83bccf468cL29-R30)

* `pkg/nodescheduler/resourcemanager.go`:
  - Reintroduced logic to handle volume mounting in `createPodTemplateSpecForPlugin`. Added safeguards such as requiring a `nodeSelector` when volumes are specified to ensure the pod is scheduled on the correct node.
  - Updated the `NodeSelector` logic to use the new `nodeSelector` variable, which incorporates the additional checks.